### PR TITLE
Improvement: issued at

### DIFF
--- a/backend/src/@types/index.ts
+++ b/backend/src/@types/index.ts
@@ -1,1 +1,2 @@
 export * from './common';
+export * from './movements';

--- a/backend/src/@types/movements.ts
+++ b/backend/src/@types/movements.ts
@@ -1,0 +1,10 @@
+import {
+  CreateTransactionInput,
+  CreateTransferInput,
+} from '../graphql/helpers';
+
+export type CreateMovementCommandInput<
+  T extends CreateTransactionInput | CreateTransferInput
+> = Pick<T, 'memo' | 'amount'> & {
+  issuedAt?: T['issuedAt'];
+};

--- a/backend/src/commands/TransactionCommands.ts
+++ b/backend/src/commands/TransactionCommands.ts
@@ -11,6 +11,7 @@ import Account from '../models/Account';
 import User from '../models/User';
 import { updateEntity } from '../utils';
 import Category from '../models/Category';
+import { CreateMovementCommandInput } from '../@types';
 
 export default class TransactionCommands {
   manager: EntityManager;
@@ -29,7 +30,11 @@ export default class TransactionCommands {
   }
 
   async create(
-    { memo, amount }: Pick<CreateTransactionInput, 'memo' | 'amount'>,
+    {
+      memo,
+      amount,
+      issuedAt,
+    }: CreateMovementCommandInput<CreateTransactionInput>,
     { account, category }: { account: Account; category?: Category },
   ): Promise<Transaction[]> {
     const rootAccount = await this.getRootAccount();
@@ -42,6 +47,7 @@ export default class TransactionCommands {
       amount,
       memo,
       accountId: account.id,
+      issuedAt,
       operationId,
       category,
     });
@@ -51,6 +57,7 @@ export default class TransactionCommands {
       memo: memo?.concat(' (root)'),
       accountId: rootAccount.id,
       operationId,
+      issuedAt,
     });
 
     await this.manager.getRepository(Account).save([account, rootAccount]);

--- a/backend/src/commands/TransferCommands.ts
+++ b/backend/src/commands/TransferCommands.ts
@@ -6,6 +6,7 @@ import { CreateTransferInput } from '../graphql/helpers';
 import Transfer from '../models/Transfer';
 import Account from '../models/Account';
 import User from '../models/User';
+import { CreateMovementCommandInput } from '../@types';
 
 export default class TransferCommands {
   manager: EntityManager;
@@ -18,7 +19,7 @@ export default class TransferCommands {
   }
 
   async create(
-    { memo, amount }: Pick<CreateTransferInput, 'memo' | 'amount'>,
+    { memo, amount, issuedAt }: CreateMovementCommandInput<CreateTransferInput>,
     { fromAccount, toAccount }: { fromAccount: Account; toAccount: Account },
   ): Promise<Transfer[]> {
     fromAccount.balance -= amount;
@@ -31,12 +32,14 @@ export default class TransferCommands {
         memo,
         accountId: fromAccount.id,
         operationId,
+        issuedAt,
       }),
       new Transfer({
         amount,
         memo,
         accountId: toAccount.id,
         operationId,
+        issuedAt,
       }),
     ]);
   }

--- a/backend/src/config/apollo.ts
+++ b/backend/src/config/apollo.ts
@@ -22,6 +22,7 @@ export const buildOwnSchema = async (): Promise<GraphQLSchema> => {
       resolve(__dirname, '..', 'models', '*'),
     ],
     authChecker,
+    dateScalarMode: 'timestamp',
   });
 };
 

--- a/backend/src/graphql/helpers/inputs/transactionInputs.ts
+++ b/backend/src/graphql/helpers/inputs/transactionInputs.ts
@@ -13,6 +13,9 @@ export class CreateTransactionInput {
 
   @Field(() => ID)
   categoryId: number;
+
+  @Field(() => Date)
+  issuedAt: Date;
 }
 
 @InputType()
@@ -31,4 +34,7 @@ export class UpdateTransactionInput {
 
   @Field(() => ID, { nullable: true })
   categoryId?: number;
+
+  @Field(() => Date, { nullable: true })
+  issuedAt?: Date;
 }

--- a/backend/src/graphql/helpers/inputs/transferInputs.ts
+++ b/backend/src/graphql/helpers/inputs/transferInputs.ts
@@ -13,4 +13,7 @@ export class CreateTransferInput {
 
   @Field({ nullable: true })
   memo?: string;
+
+  @Field(() => Date)
+  issuedAt: Date;
 }

--- a/backend/src/graphql/resolvers/transactionResolver.ts
+++ b/backend/src/graphql/resolvers/transactionResolver.ts
@@ -41,7 +41,7 @@ export default class TransactionResolvers {
       .leftJoin('transaction.account', 'account')
       .where('account.userId = :userId', { userId: currentUser!.id })
       .andWhere('account.type != :type', { type: 'root' })
-      .orderBy('transaction.createdAt', 'DESC')
+      .orderBy('transaction.issuedAt', 'DESC')
       .getMany();
   }
 

--- a/backend/src/graphql/resolvers/transferResolvers.ts
+++ b/backend/src/graphql/resolvers/transferResolvers.ts
@@ -62,7 +62,7 @@ export default class TransferResolvers {
       .select()
       .leftJoin('transfer.account', 'account')
       .where('account.userId = :userId', { userId: currentUser!.id })
-      .orderBy('transfer.createdAt', 'DESC')
+      .orderBy('transfer.issuedAt', 'DESC')
       .addOrderBy('transfer.amount', 'ASC')
       .getMany();
 

--- a/backend/src/migrations/1604547236604-AddIssuedAtToMovement.ts
+++ b/backend/src/migrations/1604547236604-AddIssuedAtToMovement.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIssuedAtToMovement1604547236604 implements MigrationInterface {
+  name = 'AddIssuedAtToMovement1604547236604';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ADD "issuedAt" TIMESTAMP NOT NULL DEFAULT 'NOW()'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "transfer" ADD "issuedAt" TIMESTAMP NOT NULL DEFAULT 'NOW()'`,
+    );
+
+    await queryRunner.query(
+      `UPDATE "transaction" SET "issuedAt" = "createdAt"`,
+    );
+
+    await queryRunner.query(`UPDATE "transfer" SET "issuedAt" = "createdAt"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "transfer" DROP COLUMN "issuedAt"`);
+    await queryRunner.query(`ALTER TABLE "transaction" DROP COLUMN "issuedAt"`);
+  }
+}

--- a/backend/src/models/Movement.ts
+++ b/backend/src/models/Movement.ts
@@ -51,12 +51,14 @@ export default abstract class Movement {
   constructor(movement: {
     amount: number;
     accountId: number;
+    issuedAt?: Date;
     memo?: string;
     operationId?: string;
   }) {
     if (movement) {
       this.amount = movement.amount;
       this.accountId = movement.accountId;
+      this.issuedAt = movement.issuedAt || new Date();
       this.memo = movement.memo === '' ? undefined : movement.memo;
       this.operationId = movement.operationId || uuid();
     }

--- a/backend/src/models/Movement.ts
+++ b/backend/src/models/Movement.ts
@@ -37,6 +37,10 @@ export default abstract class Movement {
   account: Account;
 
   @Field()
+  @Column('timestamp without time zone', { default: 'NOW()' })
+  issuedAt: Date;
+
+  @Field()
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/models/Transaction.ts
+++ b/backend/src/models/Transaction.ts
@@ -22,6 +22,7 @@ export default class Transaction extends Movement {
   constructor(transaction: {
     amount: number;
     accountId: number;
+    issuedAt?: Date;
     memo?: string;
     operationId?: string;
     category?: Category;

--- a/backend/src/models/Transfer.ts
+++ b/backend/src/models/Transfer.ts
@@ -9,6 +9,7 @@ export default class Transfer extends Movement {
   constructor(transfer: {
     amount: number;
     accountId: number;
+    issuedAt?: Date;
     memo?: string;
     operationId?: string;
   }) {

--- a/backend/src/tests/factory/transactionFactory.ts
+++ b/backend/src/tests/factory/transactionFactory.ts
@@ -8,12 +8,13 @@ import Account from '../../models/Account';
 import TransactionCommands from '../../commands/TransactionCommands';
 import Category from '../../models/Category';
 
-export type BuildType = Pick<Transaction, 'amount' | 'memo'>;
+export type BuildType = Pick<Transaction, 'amount' | 'memo' | 'issuedAt'>;
 
 export const transactionBuilder = build<BuildType>('transaction', {
   fields: {
     amount: fake((faker) => faker.random.number(15000)),
     memo: fake((faker) => faker.lorem.words(3)),
+    issuedAt: fake((faker) => faker.date.past()),
   },
 });
 

--- a/backend/src/tests/factory/transferFactory.ts
+++ b/backend/src/tests/factory/transferFactory.ts
@@ -8,12 +8,13 @@ import Transfer from '../../models/Transfer';
 import Account from '../../models/Account';
 import TransferCommands from '../../commands/TransferCommands';
 
-export type BuildType = Pick<Transfer, 'amount' | 'memo'>;
+export type BuildType = Pick<Transfer, 'amount' | 'memo' | 'issuedAt'>;
 
 export const transferBuilder = build<BuildType>('transfer', {
   fields: {
     amount: fake((faker) => faker.random.number(15000)),
     memo: fake((faker) => faker.lorem.words(3)),
+    issuedAt: fake((faker) => faker.date.past()),
   },
 });
 

--- a/web/cypress/graphql.d.ts
+++ b/web/cypress/graphql.d.ts
@@ -7,19 +7,20 @@ type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
-  DateTime: any;
+  /** The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch. */
+  Timestamp: any;
 };
 
 type GQLMovement = {
   __typename?: 'Movement';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: GQLAccount;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 
@@ -27,13 +28,14 @@ type GQLTransaction = {
   __typename?: 'Transaction';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: GQLAccount;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
   category?: Maybe<GQLCategory>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 type GQLCategory = {
@@ -42,8 +44,8 @@ type GQLCategory = {
   name: Scalars['String'];
   type: GQLCategoryType;
   color: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 type GQLCategoryType = 
@@ -61,20 +63,21 @@ type GQLUser = {
   role: Scalars['String'];
   accounts: Array<GQLAccount>;
   categories: Array<GQLCategory>;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 type GQLTransfer = {
   __typename?: 'Transfer';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: GQLAccount;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 type GQLAccount = {
@@ -85,9 +88,9 @@ type GQLAccount = {
   bank: Scalars['String'];
   balance: Scalars['Int'];
   user: GQLUser;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 type GQLAccountType = 
@@ -149,6 +152,7 @@ type GQLCreateTransactionInput = {
   accountId: Scalars['ID'];
   memo?: Maybe<Scalars['String']>;
   categoryId: Scalars['ID'];
+  issuedAt: Scalars['Timestamp'];
 };
 
 type GQLUpdateTransactionInput = {
@@ -157,6 +161,7 @@ type GQLUpdateTransactionInput = {
   memo?: Maybe<Scalars['String']>;
   accountId?: Maybe<Scalars['ID']>;
   categoryId?: Maybe<Scalars['ID']>;
+  issuedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 type GQLCreateTransferInput = {
@@ -164,6 +169,7 @@ type GQLCreateTransferInput = {
   fromAccountId: Scalars['ID'];
   toAccountId: Scalars['ID'];
   memo?: Maybe<Scalars['String']>;
+  issuedAt: Scalars['Timestamp'];
 };
 
 type GQLQuery = {

--- a/web/cypress/integration/movements/transactions.test.ts
+++ b/web/cypress/integration/movements/transactions.test.ts
@@ -66,6 +66,8 @@ describe('transactions table', () => {
     cy.get('tbody tr').should('have.length', 1);
   });
 
+  /* TODO: figure a way of testing the date dynamically */
+
   it('should be able to update a transaction', () => {
     const rowId = `row${testTransaction.id}`;
     const updateId = `updateTransaction${testTransaction.id}`;

--- a/web/cypress/support/build/transaction.ts
+++ b/web/cypress/support/build/transaction.ts
@@ -12,6 +12,7 @@ export const buildTransaction = (overrides?: Partial<BaseTransaction>) => {
     fields: {
       amount: fake((faker) => faker.random.number(2000000)),
       memo: fake((faker) => faker.lorem.words(3)),
+      issuedAt: fake((faker) => faker.date.past()),
     },
   });
   return builder({ map: (transaction) => ({ ...transaction, ...overrides }) });

--- a/web/cypress/support/build/transfer.ts
+++ b/web/cypress/support/build/transfer.ts
@@ -9,6 +9,7 @@ export const buildTransfer = (overrides?: Partial<BaseTransfer>) => {
     fields: {
       amount: fake((faker) => faker.random.number(2000000)),
       memo: fake((faker) => faker.lorem.words(3)),
+      issuedAt: fake((faker) => faker.date.past()),
     },
   });
 

--- a/web/package.json
+++ b/web/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.2.0",
+    "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
+    "@material-ui/pickers": "^3.2.10",
     "@reduxjs/toolkit": "^1.4.0",
     "@types/accounting": "^0.4.1",
     "@types/jest": "^26.0.14",

--- a/web/src/@types/graphql.ts
+++ b/web/src/@types/graphql.ts
@@ -7,19 +7,20 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
-  DateTime: any;
+  /** The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch. */
+  Timestamp: any;
 };
 
 export type Movement = {
   __typename?: 'Movement';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: Account;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 
@@ -27,13 +28,14 @@ export type Transaction = {
   __typename?: 'Transaction';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: Account;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
   category?: Maybe<Category>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export type Category = {
@@ -42,8 +44,8 @@ export type Category = {
   name: Scalars['String'];
   type: CategoryType;
   color: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 export enum CategoryType {
@@ -62,20 +64,21 @@ export type User = {
   role: Scalars['String'];
   accounts: Array<Account>;
   categories: Array<Category>;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export type Transfer = {
   __typename?: 'Transfer';
   id: Scalars['ID'];
   amount: Scalars['Int'];
-  memo: Scalars['String'];
+  memo?: Maybe<Scalars['String']>;
   operationId: Scalars['String'];
   account: Account;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
 };
 
 export type Account = {
@@ -86,9 +89,9 @@ export type Account = {
   bank: Scalars['String'];
   balance: Scalars['Int'];
   user: User;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export enum AccountType {
@@ -151,6 +154,7 @@ export type CreateTransactionInput = {
   accountId: Scalars['ID'];
   memo?: Maybe<Scalars['String']>;
   categoryId: Scalars['ID'];
+  issuedAt: Scalars['Timestamp'];
 };
 
 export type UpdateTransactionInput = {
@@ -159,6 +163,7 @@ export type UpdateTransactionInput = {
   memo?: Maybe<Scalars['String']>;
   accountId?: Maybe<Scalars['ID']>;
   categoryId?: Maybe<Scalars['ID']>;
+  issuedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export type CreateTransferInput = {
@@ -166,6 +171,7 @@ export type CreateTransferInput = {
   fromAccountId: Scalars['ID'];
   toAccountId: Scalars['ID'];
   memo?: Maybe<Scalars['String']>;
+  issuedAt: Scalars['Timestamp'];
 };
 
 export type Query = {
@@ -406,7 +412,7 @@ export type MyTransactionsQuery = (
   { __typename?: 'Query' }
   & { transactions: Array<(
     { __typename?: 'Transaction' }
-    & Pick<Transaction, 'id' | 'amount' | 'memo' | 'createdAt'>
+    & Pick<Transaction, 'id' | 'amount' | 'memo' | 'issuedAt'>
     & { account: (
       { __typename?: 'Account' }
       & Pick<Account, 'id' | 'name' | 'bank' | 'balance'>
@@ -439,7 +445,7 @@ export type UpdateTransactionMutation = (
   { __typename?: 'Mutation' }
   & { updateTransaction: (
     { __typename?: 'Transaction' }
-    & Pick<Transaction, 'id' | 'amount' | 'memo' | 'createdAt'>
+    & Pick<Transaction, 'id' | 'amount' | 'memo' | 'issuedAt'>
     & { account: (
       { __typename?: 'Account' }
       & Pick<Account, 'id' | 'name' | 'bank' | 'balance'>
@@ -469,14 +475,14 @@ export type MyTransfersQuery = (
     { __typename?: 'PairedTransfer' }
     & { from: (
       { __typename?: 'Transfer' }
-      & Pick<Transfer, 'id' | 'amount' | 'memo' | 'operationId' | 'createdAt'>
+      & Pick<Transfer, 'id' | 'amount' | 'memo' | 'operationId' | 'issuedAt'>
       & { account: (
         { __typename?: 'Account' }
         & Pick<Account, 'id' | 'name'>
       ) }
     ), to: (
       { __typename?: 'Transfer' }
-      & Pick<Transfer, 'id' | 'amount' | 'memo' | 'operationId' | 'createdAt'>
+      & Pick<Transfer, 'id' | 'amount' | 'memo' | 'operationId' | 'issuedAt'>
       & { account: (
         { __typename?: 'Account' }
         & Pick<Account, 'id' | 'name'>

--- a/web/src/@types/helpers.ts
+++ b/web/src/@types/helpers.ts
@@ -5,6 +5,8 @@ export type ElementOf<T extends ReadonlyArray<unknown>> = T extends ReadonlyArra
   ? Element
   : never;
 
+export type ArgumentOf<T> = T extends (...args: infer U) => any ? U : never;
+
 export type InputMutationTuple<TData, TVariables extends { input: any }> = [
   (input: TVariables['input']) => ReturnType<MutationTuple<TData, TVariables>[0]>,
   MutationTuple<TData, TVariables>[1],

--- a/web/src/AppProviders.tsx
+++ b/web/src/AppProviders.tsx
@@ -6,6 +6,8 @@ import { Close as CloseIcon } from '@material-ui/icons';
 import { SnackbarProvider } from 'notistack';
 import { BrowserRouter as RouterProvider } from 'react-router-dom';
 import { Provider, useSelector } from 'react-redux';
+import { MuiPickersUtilsProvider as DatepickerProvider } from '@material-ui/pickers';
+import DayJsUtils from '@date-io/dayjs';
 
 import './config/accounting';
 import client from './config/apollo';
@@ -75,8 +77,10 @@ const AppProviders: React.FC = ({ children }) => (
       <ApolloProvider client={client}>
         <CustomThemeProvider>
           <CustomSnackbarProvider>
-            <CssBaseline />
-            {children}
+            <DatepickerProvider utils={DayJsUtils}>
+              <CssBaseline />
+              {children}
+            </DatepickerProvider>
           </CustomSnackbarProvider>
         </CustomThemeProvider>
       </ApolloProvider>

--- a/web/src/components/formik/FormikDatepicker.tsx
+++ b/web/src/components/formik/FormikDatepicker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DateTimePicker, DateTimePickerProps } from '@material-ui/pickers';
 import { useField } from 'formik';
-import { makeStyles } from '@material-ui/core';
+import { InputProps, makeStyles } from '@material-ui/core';
 import { longDateFormat } from '../../utils/date';
 
 interface Props {
@@ -37,6 +37,7 @@ const FormikDatepicker: React.FC<Props & Omit<DateTimePickerProps, 'value' | 'on
       helperText={hasError && error}
       disableFuture
       DialogProps={{ className: classes.dialog }}
+      InputProps={({ 'data-testid': `${name}Input` } as unknown) as InputProps}
       {...otherProps}
       {...props}
     />

--- a/web/src/components/formik/FormikDatepicker.tsx
+++ b/web/src/components/formik/FormikDatepicker.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { DateTimePicker, DateTimePickerProps } from '@material-ui/pickers';
+import { useField } from 'formik';
+import { makeStyles } from '@material-ui/core';
+import { longDateFormat } from '../../utils/date';
+
+interface Props {
+  name: string;
+  label: string;
+}
+
+const useStyles = makeStyles((theme) => ({
+  dialog: {
+    '& .MuiDialogActions-root button.MuiButtonBase-root': { color: theme.palette.secondary.main },
+  },
+}));
+
+const FormikDatepicker: React.FC<Props & Omit<DateTimePickerProps, 'value' | 'onChange'>> = ({
+  name,
+  label,
+  ...props
+}) => {
+  const classes = useStyles();
+  const [{ value, onChange, ...otherProps }, { error, touched }, { setValue }] = useField(name);
+  const hasError = touched && !!error;
+
+  return (
+    <DateTimePicker
+      inputVariant="outlined"
+      fullWidth
+      color="secondary"
+      value={value}
+      label={label}
+      onChange={(date) => setValue(date)}
+      format={longDateFormat}
+      error={hasError}
+      helperText={hasError && error}
+      disableFuture
+      DialogProps={{ className: classes.dialog }}
+      {...otherProps}
+      {...props}
+    />
+  );
+};
+
+export default FormikDatepicker;

--- a/web/src/components/transactions/CreateTransactionDialog.tsx
+++ b/web/src/components/transactions/CreateTransactionDialog.tsx
@@ -21,6 +21,7 @@ const CreateTransactionDialog: React.FC = () => {
       amount: initialEmptyNumber,
       type: 'Expense',
       memo: '',
+      issuedAt: new Date(),
       accountId: (accounts && accounts[0].id) || '',
       categoryId: (expense && expense[0].id) || '',
     }),

--- a/web/src/components/transactions/TransactionFormView.tsx
+++ b/web/src/components/transactions/TransactionFormView.tsx
@@ -11,6 +11,7 @@ import ContainerLoader from '../ui/misc/ContainerLoader';
 import DialogFormButtons from '../ui/dialogs/DialogFormButtons';
 import CategorySelectItem from '../ui/misc/CategorySelectItem';
 import FormikCurrencyField from '../formik/FormikCurrencyField';
+import FormikDatepicker from '../formik/FormikDatepicker';
 
 type Props<T> = {
   initialValues: T;
@@ -50,6 +51,7 @@ const TransactionFormView = <T extends Record<string, unknown>>({
         memo: yup.string(),
         accountId: yup.string().required(),
         categoryId: yup.string(),
+        issuedAt: yup.date().max(new Date()).required(),
       })}
       onSubmit={onSubmit}
     >
@@ -79,13 +81,25 @@ const TransactionFormView = <T extends Record<string, unknown>>({
                   <Grid item xs={12}>
                     <FormikCurrencyField name="amount" label="Amount" fullWidth />
                   </Grid>
-                  <Grid item xs={12}>
+                  <Grid item xs={6}>
                     <FormikSelectField
                       name="type"
                       label="Transaction type"
                       fullWidth
                       displayEmpty
                       options={['Expense', 'Income']}
+                    />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <FormikSelectField
+                      name="categoryId"
+                      label="Category"
+                      fullWidth
+                      displayEmpty
+                      options={internalCategories.map((category) => ({
+                        key: category.id,
+                        element: <CategorySelectItem category={category} key={category.id} />,
+                      }))}
                     />
                   </Grid>
                   <Grid item xs={12}>
@@ -104,16 +118,7 @@ const TransactionFormView = <T extends Record<string, unknown>>({
                     />
                   </Grid>
                   <Grid item xs={12}>
-                    <FormikSelectField
-                      name="categoryId"
-                      label="Category"
-                      fullWidth
-                      displayEmpty
-                      options={internalCategories.map((category) => ({
-                        key: category.id,
-                        element: <CategorySelectItem category={category} key={category.id} />,
-                      }))}
-                    />
+                    <FormikDatepicker name="issuedAt" label="Issued at" />
                   </Grid>
                 </Grid>
               )}

--- a/web/src/components/transactions/TransactionsTable.tsx
+++ b/web/src/components/transactions/TransactionsTable.tsx
@@ -2,12 +2,12 @@ import React, { useMemo } from 'react';
 import { makeStyles, Typography, Box } from '@material-ui/core';
 import { Column } from 'react-table';
 import { formatMoney } from 'accounting';
-import dayjs from 'dayjs';
 import clsx from 'clsx';
 import { MyTransactionsQuery } from '../../@types/graphql';
 import EnhancedTable from '../ui/dataDisplay/EnhancedTable';
 import TransactionActionCell from './TransactionActionCell';
 import CategoryIcon from '../ui/misc/CategoryIcon';
+import { longDateFormatter } from '../../utils/date';
 
 const useStyles = makeStyles((theme) => ({
   table: { flex: 1 },
@@ -70,8 +70,8 @@ const TransactionsTable: React.FC<Props> = ({
       },
       {
         Header: 'Date',
-        accessor: 'createdAt',
-        Cell: ({ value }) => dayjs(value).format('HH:mm DD/MM/YYYY'),
+        accessor: 'issuedAt',
+        Cell: ({ value }) => longDateFormatter(value),
       },
       {
         Header: 'Actions',

--- a/web/src/components/transactions/UpdateTransactionDialog.tsx
+++ b/web/src/components/transactions/UpdateTransactionDialog.tsx
@@ -29,6 +29,7 @@ const UpdateTransactionDialog: React.FC<Props> = ({ transaction }) => {
       memo: transaction.memo || '',
       accountId: transaction.account.id,
       categoryId: transaction.category?.id || '',
+      issuedAt: new Date(transaction.issuedAt),
     }),
     [transaction],
   );

--- a/web/src/components/transfers/CreateTransferDialog.tsx
+++ b/web/src/components/transfers/CreateTransferDialog.tsx
@@ -20,6 +20,7 @@ const CreateTransferDialog: React.FC = () => {
       memo: '',
       fromAccountId: (accounts && accounts[0].id) || '',
       toAccountId: (accounts && accounts[1].id) || '',
+      issuedAt: new Date(),
     }),
     [accounts],
   );

--- a/web/src/components/transfers/TransferFormView.tsx
+++ b/web/src/components/transfers/TransferFormView.tsx
@@ -10,6 +10,7 @@ import ContainerLoader from '../ui/misc/ContainerLoader';
 import DialogFormButtons from '../ui/dialogs/DialogFormButtons';
 import { MyAccountsQuery } from '../../@types/graphql';
 import FormikCurrencyField from '../formik/FormikCurrencyField';
+import FormikDatepicker from '../formik/FormikDatepicker';
 
 type Props<T> = {
   initialValues: T;
@@ -50,6 +51,7 @@ const TransferFormView = <T extends Record<string, unknown>>({
           .string()
           .notOneOf([yup.ref('fromAccountId')], 'Must be different from destination account')
           .required(),
+        issuedAt: yup.date().max(new Date()).required(),
       })}
       onSubmit={onSubmit}
     >
@@ -67,7 +69,7 @@ const TransferFormView = <T extends Record<string, unknown>>({
                 <Grid item xs={12}>
                   <FormikTextField name="memo" label="Memo" fullWidth />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item xs={6}>
                   <FormikSelectField
                     name="fromAccountId"
                     label="Origin account"
@@ -79,7 +81,7 @@ const TransferFormView = <T extends Record<string, unknown>>({
                     }))}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item xs={6}>
                   <FormikSelectField
                     name="toAccountId"
                     label="Destination account"
@@ -90,6 +92,9 @@ const TransferFormView = <T extends Record<string, unknown>>({
                       label: `${name} (${bank})`,
                     }))}
                   />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormikDatepicker name="issuedAt" label="Issued at" />
                 </Grid>
               </Grid>
             )}

--- a/web/src/components/transfers/TransfersTable.tsx
+++ b/web/src/components/transfers/TransfersTable.tsx
@@ -2,11 +2,11 @@ import React, { useMemo } from 'react';
 import { makeStyles, Typography, Box } from '@material-ui/core';
 import { Column, CellProps } from 'react-table';
 import { formatMoney } from 'accounting';
-import dayjs from 'dayjs';
 import { TrendingFlat as TransferIcon } from '@material-ui/icons';
 import { MyTransfersQuery } from '../../@types/graphql';
 import EnhancedTable from '../ui/dataDisplay/EnhancedTable';
 import TransferActionCell from './TransferActionCell';
+import { longDateFormatter } from '../../utils/date';
 
 const useStyles = makeStyles((theme) => ({
   table: { flex: 1 },
@@ -59,9 +59,8 @@ const TransfersTable: React.FC<Props> = ({ children, transfers, loading, notEnou
       },
       {
         Header: 'Date',
-        id: 'createdAt',
-        Cell: ({ row }: CustomCellProps) =>
-          dayjs(row.original.from.createdAt).format('HH:mm DD/MM/YYYY'),
+        id: 'issuedAt',
+        Cell: ({ row }: CustomCellProps) => longDateFormatter(row.original.from.issuedAt),
       },
       {
         Header: 'Actions',

--- a/web/src/config/yup.ts
+++ b/web/src/config/yup.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-template-curly-in-string */
 import { setLocale } from 'yup';
+import { longDateFormatter } from '../utils/date';
 
 setLocale({
   mixed: { required: 'This field is required' },
   string: { email: 'Invalid email', min: 'Must be at least ${min} characters long' },
   number: { min: ({ min }) => `Must be greater than ${min - 1}` },
+  date: { max: ({ max }) => `Must be earlier than ${longDateFormatter(max)}` },
 });

--- a/web/src/graphql/transaction.ts
+++ b/web/src/graphql/transaction.ts
@@ -17,7 +17,7 @@ export const myTransactionsQuery = gql`
         name
         color
       }
-      createdAt
+      issuedAt
     }
   }
 `;
@@ -47,7 +47,7 @@ export const updateTransactionMutation = gql`
         name
         color
       }
-      createdAt
+      issuedAt
     }
   }
 `;

--- a/web/src/graphql/transfer.ts
+++ b/web/src/graphql/transfer.ts
@@ -12,7 +12,7 @@ export const myTransfersQuery = gql`
           id
           name
         }
-        createdAt
+        issuedAt
       }
       to {
         id
@@ -23,7 +23,7 @@ export const myTransfersQuery = gql`
           id
           name
         }
-        createdAt
+        issuedAt
       }
     }
   }

--- a/web/src/hooks/graphql/transactions.ts
+++ b/web/src/hooks/graphql/transactions.ts
@@ -39,7 +39,10 @@ export const useCreateTransaction = (): InputMutationTuple<
 export const useUpdateTransaction = (): InputMutationTuple<
   UpdateTransactionMutation,
   UpdateTransactionMutationVariables
-> => useInputMutation(updateTransactionMutation, { refetchQueries: [{ query: myAccountsQuery }] });
+> =>
+  useInputMutation(updateTransactionMutation, {
+    refetchQueries: [{ query: myAccountsQuery }, { query: myTransactionsQuery }],
+  });
 
 export const useDeleteTransaction = (): UseIdMutationReturn<DeleteTransactionMutation> => {
   return useIdMutation<DeleteTransactionMutation>(deleteTransactionMutation, {

--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+import { ArgumentOf } from '../@types/helpers';
+
+export const longDateFormat = 'HH:mm DD/MM/YYYY';
+
+export const longDateFormatter = (date: ArgumentOf<typeof dayjs>[0]): string =>
+  dayjs(date).format(longDateFormat);

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1172,6 +1172,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1276,6 +1283,18 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
+  integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
+
+"@date-io/dayjs@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-1.3.13.tgz#3a9edf5a7227b31b0f00a4f640f8715626833a61"
+  integrity sha512-nD39xWYwQjDMIdpUzHIcADHxY9m1hm1DpOaRn3bc2rBdgmwQC0PfW0WYaHyGGP/6LEzEguINRbHuotMhf+T9Sg==
+  dependencies:
+    "@date-io/core" "^1.3.13"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -1379,21 +1398,6 @@
     tslib "~2.0.1"
 
 "@graphql-codegen/visitor-plugin-common@^1.17.13", "@graphql-codegen/visitor-plugin-common@^1.17.14":
-  version "1.17.14"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.14.tgz#dfd15932a2d9f2a0be3ce945206a173609908769"
-  integrity sha512-tHVkMqQcWuq5xuXm7q8JKcKUVdEYaT61Hnz1OZNgYCBQIOCKUljZcmPuy3F8aJU29XHyZ2vwF2hNG6q4CE3fcQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.8"
-    "@graphql-tools/relay-operation-optimizer" "^6.0.18"
-    array.prototype.flatmap "^1.2.3"
-    auto-bind "~4.0.0"
-    dependency-graph "^0.9.0"
-    graphql-tag "^2.11.0"
-    parse-filepath "^1.0.2"
-    pascal-case "^3.1.1"
-    tslib "~2.0.1"
-
-"@graphql-codegen/visitor-plugin-common@^1.17.14":
   version "1.17.14"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.14.tgz#dfd15932a2d9f2a0be3ce945206a173609908769"
   integrity sha512-tHVkMqQcWuq5xuXm7q8JKcKUVdEYaT61Hnz1OZNgYCBQIOCKUljZcmPuy3F8aJU29XHyZ2vwF2hNG6q4CE3fcQ==
@@ -1604,11 +1608,6 @@
     "@graphql-tools/utils" "6.2.3"
     is-promise "4.0.0"
     tslib "~2.0.1"
-
-"@graphql-typed-document-node/core@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.0"
@@ -1894,6 +1893,18 @@
     clsx "^1.0.4"
     prop-types "^15.7.2"
     react-is "^16.8.0"
+
+"@material-ui/pickers@^3.2.10":
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.10.tgz#19df024895876eb0ec7cd239bbaea595f703f0ae"
+  integrity sha512-B8G6Obn5S3RCl7hwahkQj9sKUapwXWFjiaz/Bsw1fhYFdNMnDUolRiWQSoKPb1/oKe37Dtfszoywi1Ynbo3y8w==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@date-io/core" "1.x"
+    "@types/styled-jsx" "^2.2.8"
+    clsx "^1.0.2"
+    react-transition-group "^4.0.0"
+    rifm "^0.7.0"
 
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
@@ -2266,14 +2277,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/jest@^26.0.14":
-  version "26.0.14"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.14.tgz#078695f8f65cb55c5a98450d65083b2b73e5a3f3"
-  integrity sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==
-  dependencies:
-    jest-diff "^25.2.1"
-    pretty-format "^25.2.1"
-
 "@types/js-yaml@^3.12.5":
   version "3.12.5"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
@@ -2312,11 +2315,6 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*", "@types/node@^14.11.2":
-  version "14.11.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
-  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
-
-"@types/node@^14.11.2":
   version "14.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
   integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
@@ -2414,14 +2412,6 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@^16.9.49":
-  version "16.9.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
 "@types/reactcss@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/reactcss/-/reactcss-1.2.3.tgz#af28ae11bbb277978b99d04d1eedfd068ca71834"
@@ -2443,6 +2433,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/styled-jsx@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/testing-library__cypress@^5.0.7":
   version "5.0.8"
@@ -4038,7 +4035,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -4720,50 +4717,6 @@ cypress@*, cypress@^5.2.0:
     url "^0.11.0"
     yauzl "^2.10.0"
 
-cypress@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.2.0.tgz#6902efd90703242a2539f0623c6e1118aff01f95"
-  integrity sha512-9S2spcrpIXrQ+CQIKHsjRoLQyRc2ehB06clJXPXXp1zyOL/uZMM3Qc20ipNki4CcNwY0nBTQZffPbRpODeGYQg==
-  dependencies:
-    "@cypress/listr-verbose-renderer" "^0.4.1"
-    "@cypress/request" "^2.88.5"
-    "@cypress/xvfb" "^1.2.4"
-    "@types/sinonjs__fake-timers" "^6.0.1"
-    "@types/sizzle" "^2.3.2"
-    arch "^2.1.2"
-    blob-util "2.0.2"
-    bluebird "^3.7.2"
-    cachedir "^2.3.0"
-    chalk "^4.1.0"
-    check-more-types "^2.24.0"
-    cli-table3 "~0.6.0"
-    commander "^4.1.1"
-    common-tags "^1.8.0"
-    debug "^4.1.1"
-    eventemitter2 "^6.4.2"
-    execa "^4.0.2"
-    executable "^4.1.1"
-    extract-zip "^1.7.0"
-    fs-extra "^9.0.1"
-    getos "^3.2.1"
-    is-ci "^2.0.0"
-    is-installed-globally "^0.3.2"
-    lazy-ass "^1.6.0"
-    listr "^0.14.3"
-    lodash "^4.17.19"
-    log-symbols "^4.0.0"
-    minimist "^1.2.5"
-    moment "^2.27.0"
-    ospath "^1.2.2"
-    pretty-bytes "^5.3.0"
-    ramda "~0.26.1"
-    request-progress "^3.0.0"
-    supports-color "^7.1.0"
-    tmp "~0.2.1"
-    untildify "^4.0.0"
-    url "^0.11.0"
-    yauzl "^2.10.0"
-
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -4826,13 +4779,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
     ms "2.0.0"
 
 debug@4, debug@4.2.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
@@ -5061,11 +5007,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-accessibility-api@^0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz#ef3cdb5d3f0d599d8f9c8b18df2fb63c9793739d"
-  integrity sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==
 
 dom-accessibility-api@^0.5.1:
   version "0.5.2"
@@ -11122,7 +11063,7 @@ react-table@^7.5.1:
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.5.1.tgz#b6a9b46e52c0f37ff91717ac478f430c6a357e41"
   integrity sha512-rprrUElCqvj79lyY2XbUoYLzwA5Mm4CGS8ElQ8OyzocvmkvCcmunvvfbpIg9Jm9HnMBjVZcVyPFPZ1BFelIBKw==
 
-react-transition-group@^4.4.0:
+react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -11625,6 +11566,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
+
+rifm@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
+  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 rimraf@2.6.3:
   version "2.6.3"


### PR DESCRIPTION
# Improvement: issued at

## Description
Add `issuedAt` attribute to movements models (`Transaction` and `Transfer`). Integrated a custom material datetime picker. Images of the new UI attached.

![Screenshot_20201107_233553](https://user-images.githubusercontent.com/14133074/98455623-fddb3000-2151-11eb-82ae-7be167c6143e.png)

![Screenshot_20201107_233617](https://user-images.githubusercontent.com/14133074/98455630-0df30f80-2152-11eb-8a85-29f15ac60f92.png)

## Additional changes
Changed the way of handling dates in Apollo. Now we use timestamps on response and any on request.
