### PR TITLE
Fix: duplicate named categories

### DIFF
--- a/backend/src/migrations/1604848047017-FixDefaultIssuedAtOnMovements.ts
+++ b/backend/src/migrations/1604848047017-FixDefaultIssuedAtOnMovements.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixDefaultIssuedAtOnMovements1604848047017
+  implements MigrationInterface {
+  name = 'FixDefaultIssuedAtOnMovements1604848047017';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ALTER COLUMN "issuedAt" SET DEFAULT NOW()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transfer" ALTER COLUMN "issuedAt" SET DEFAULT NOW()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transfer" ALTER COLUMN "issuedAt" SET DEFAULT 'NOW()'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ALTER COLUMN "issuedAt" SET DEFAULT 'NOW()'`,
+    );
+  }
+}

--- a/backend/src/migrations/1604848133456-ChangeUniquenessOfCategory.ts
+++ b/backend/src/migrations/1604848133456-ChangeUniquenessOfCategory.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ChangeUniquenessOfCategory1604848133456 implements MigrationInterface {
+    name = 'ChangeUniquenessOfCategory1604848133456'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "UQ_4760fde1380c4d39297a2e1f98c"`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "UQ_9c02d63f9578dcd8e1543a132de" UNIQUE ("name", "userId", "type")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "UQ_9c02d63f9578dcd8e1543a132de"`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "UQ_4760fde1380c4d39297a2e1f98c" UNIQUE ("name", "userId")`);
+    }
+
+}

--- a/backend/src/models/Category.ts
+++ b/backend/src/models/Category.ts
@@ -16,7 +16,7 @@ import { CategoryType } from '../graphql/helpers';
 import colors from '../constants/colors';
 
 @Entity()
-@Unique(['name', 'userId'])
+@Unique(['name', 'userId', 'type'])
 @ObjectType()
 export default class Category {
   @Field(() => ID)

--- a/backend/src/models/Movement.ts
+++ b/backend/src/models/Movement.ts
@@ -37,7 +37,7 @@ export default abstract class Movement {
   account: Account;
 
   @Field()
-  @Column('timestamp without time zone', { default: 'NOW()' })
+  @Column('timestamp without time zone', { default: () => 'NOW()' })
   issuedAt: Date;
 
   @Field()


### PR DESCRIPTION
# Fix: duplicate named categories

## Description
Fixed issue where two categories with the same name but different type weren't possible.

## Additional changes
Fixed an issue with the `issuedAt` migration on movements. It was using as default value the date of the execution of the migration.
