### PR TITLE
Feature: update categories

### DIFF
--- a/backend/src/graphql/helpers/inputs/categoryInputs.ts
+++ b/backend/src/graphql/helpers/inputs/categoryInputs.ts
@@ -1,4 +1,4 @@
-import { InputType, Field } from 'type-graphql';
+import { InputType, Field, ID } from 'type-graphql';
 import { CategoryType } from '../enums';
 
 @InputType()
@@ -11,4 +11,19 @@ export class CreateCategoryInput {
 
   @Field(() => CategoryType)
   type: CategoryType;
+}
+
+@InputType()
+export class UpdateCategoryInput {
+  @Field(() => ID)
+  id: number;
+
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  color?: string;
+
+  @Field(() => CategoryType, { nullable: true })
+  type?: CategoryType;
 }

--- a/web/cypress/integration/categories/categories.test.ts
+++ b/web/cypress/integration/categories/categories.test.ts
@@ -1,11 +1,20 @@
+import { capitalize } from 'lodash';
 import { validationMatchers } from '../../support/matchers';
 import { buildCategory } from '../../support/build/category';
 
 const { requiredField } = validationMatchers;
 
 describe('categories view', () => {
+  let testCategory: GQLCreateCategoryMutation['createCategory'];
+
   beforeEach(() => {
-    cy.fixture('adminUser').then((user) => cy.login(user.username, user.password));
+    cy.fixture('adminUser')
+      .then((user) => cy.login(user.username, user.password))
+      .then(() => cy.createCategory(buildCategory()))
+      .then((category) => {
+        testCategory = category;
+      });
+
     cy.visit('/categories');
   });
 
@@ -26,6 +35,24 @@ describe('categories view', () => {
 
     /* should show created category */
     cy.findByText(newCategory.name).should('exist');
+  });
+
+  it('should be able to update a category', () => {
+    const modifiedCategory = buildCategory();
+
+    cy.findByTestId(`updateCategory${testCategory.id}`).should('exist').click();
+
+    /* change fields and submit */
+    cy.findByTestId(`nameInput`).within(() => cy.get('input').clear().type(modifiedCategory.name));
+    cy.changeSelectOption('typeInput', capitalize(modifiedCategory.type));
+    cy.changeColor('colorInput');
+    cy.submitForm();
+
+    /* should notify changes */
+    cy.findByText(/category updated/i).should('exist');
+
+    // /* should show created category */
+    cy.findByText(modifiedCategory.name).should('exist');
   });
 
   it('should validate category fields', () => {

--- a/web/src/@types/graphql.ts
+++ b/web/src/@types/graphql.ts
@@ -11,33 +11,6 @@ export type Scalars = {
   Timestamp: any;
 };
 
-export type Movement = {
-  __typename?: 'Movement';
-  id: Scalars['ID'];
-  amount: Scalars['Int'];
-  memo?: Maybe<Scalars['String']>;
-  operationId: Scalars['String'];
-  account: Account;
-  issuedAt: Scalars['Timestamp'];
-  createdAt: Scalars['Timestamp'];
-  updatedAt: Scalars['Timestamp'];
-};
-
-
-export type Transaction = {
-  __typename?: 'Transaction';
-  id: Scalars['ID'];
-  amount: Scalars['Int'];
-  memo?: Maybe<Scalars['String']>;
-  operationId: Scalars['String'];
-  account: Account;
-  issuedAt: Scalars['Timestamp'];
-  createdAt: Scalars['Timestamp'];
-  updatedAt: Scalars['Timestamp'];
-  category?: Maybe<Category>;
-  deletedAt?: Maybe<Scalars['Timestamp']>;
-};
-
 export type Category = {
   __typename?: 'Category';
   id: Scalars['ID'];
@@ -53,19 +26,30 @@ export enum CategoryType {
   Expense = 'expense'
 }
 
-export type User = {
-  __typename?: 'User';
+
+export type Movement = {
+  __typename?: 'Movement';
   id: Scalars['ID'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  name: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-  role: Scalars['String'];
-  accounts: Array<Account>;
-  categories: Array<Category>;
+  amount: Scalars['Int'];
+  memo?: Maybe<Scalars['String']>;
+  operationId: Scalars['String'];
+  account: Account;
+  issuedAt: Scalars['Timestamp'];
   createdAt: Scalars['Timestamp'];
   updatedAt: Scalars['Timestamp'];
+};
+
+export type Transaction = {
+  __typename?: 'Transaction';
+  id: Scalars['ID'];
+  amount: Scalars['Int'];
+  memo?: Maybe<Scalars['String']>;
+  operationId: Scalars['String'];
+  account: Account;
+  issuedAt: Scalars['Timestamp'];
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  category?: Maybe<Category>;
   deletedAt?: Maybe<Scalars['Timestamp']>;
 };
 
@@ -99,6 +83,22 @@ export enum AccountType {
   Vista = 'vista',
   Checking = 'checking'
 }
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['ID'];
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  name: Scalars['String'];
+  email: Scalars['String'];
+  username: Scalars['String'];
+  role: Scalars['String'];
+  accounts: Array<Account>;
+  categories: Array<Category>;
+  createdAt: Scalars['Timestamp'];
+  updatedAt: Scalars['Timestamp'];
+  deletedAt?: Maybe<Scalars['Timestamp']>;
+};
 
 export type PairedTransfer = {
   __typename?: 'PairedTransfer';
@@ -147,6 +147,13 @@ export type CreateCategoryInput = {
   name: Scalars['String'];
   color: Scalars['String'];
   type: CategoryType;
+};
+
+export type UpdateCategoryInput = {
+  id: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+  color?: Maybe<Scalars['String']>;
+  type?: Maybe<CategoryType>;
 };
 
 export type CreateTransactionInput = {
@@ -204,6 +211,7 @@ export type Mutation = {
   login: Scalars['String'];
   signUp: Scalars['String'];
   createCategory: Category;
+  updateCategory: Category;
   deleteCategory: Scalars['ID'];
   setupDatabase?: Maybe<User>;
   createTransaction: Transaction;
@@ -241,6 +249,11 @@ export type MutationSignUpArgs = {
 
 export type MutationCreateCategoryArgs = {
   input: CreateCategoryInput;
+};
+
+
+export type MutationUpdateCategoryArgs = {
+  input: UpdateCategoryInput;
 };
 
 
@@ -375,10 +388,10 @@ export type MyCategoriesQuery = (
   { __typename?: 'Query' }
   & { income: Array<(
     { __typename?: 'Category' }
-    & Pick<Category, 'id' | 'name' | 'color'>
+    & Pick<Category, 'id' | 'name' | 'color' | 'type'>
   )>, expense: Array<(
     { __typename?: 'Category' }
-    & Pick<Category, 'id' | 'name' | 'color'>
+    & Pick<Category, 'id' | 'name' | 'color' | 'type'>
   )> }
 );
 
@@ -392,6 +405,19 @@ export type CreateCategoryMutation = (
   & { createCategory: (
     { __typename?: 'Category' }
     & Pick<Category, 'id'>
+  ) }
+);
+
+export type UpdateCategoryMutationVariables = Exact<{
+  input: UpdateCategoryInput;
+}>;
+
+
+export type UpdateCategoryMutation = (
+  { __typename?: 'Mutation' }
+  & { updateCategory: (
+    { __typename?: 'Category' }
+    & Pick<Category, 'id' | 'name' | 'type' | 'color'>
   ) }
 );
 

--- a/web/src/components/categories/CategoryGridItem.tsx
+++ b/web/src/components/categories/CategoryGridItem.tsx
@@ -5,6 +5,8 @@ import { MyCategoriesQuery } from '../../@types/graphql';
 import CategorySelectItem from '../ui/misc/CategorySelectItem';
 import EnhancedIconButton from '../ui/misc/EnhancedIconButton';
 import { useDeleteCategory } from '../../hooks/graphql';
+import DialogIconButton from '../ui/dialogs/DialogIconButton';
+import UpdateCategoryDialog from './UpdateCategoryDialog';
 
 interface Props {
   category: MyCategoriesQuery['income'][number];
@@ -27,9 +29,15 @@ const CategoryGridItem: React.FC<Props> = ({ category }) => {
   return (
     <Paper data-testid={`category${category.id}`} className={classes.paper} elevation={1}>
       <CategorySelectItem className={classes.category} category={category} />
-      <EnhancedIconButton size="small" disabled contained color="info">
-        <EditIcon fontSize="small" />
-      </EnhancedIconButton>
+      <DialogIconButton
+        size="small"
+        contained
+        icon={<EditIcon fontSize="small" />}
+        data-testid={`updateCategory${category.id}`}
+        color="info"
+      >
+        <UpdateCategoryDialog category={category} />
+      </DialogIconButton>
       <EnhancedIconButton
         size="small"
         contained

--- a/web/src/components/categories/UpdateCategoryDialog.tsx
+++ b/web/src/components/categories/UpdateCategoryDialog.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import React, { useMemo, useContext } from 'react';
+
+import CategoryFormView from './CategoryFormView';
+import DialogFormContext from '../../contexts/DialogFormContext';
+import { useUpdateCategory } from '../../hooks/graphql';
+import { MyCategoriesQuery } from '../../@types/graphql';
+
+interface Props {
+  category: MyCategoriesQuery['income'][number];
+}
+
+const UpdateCategoryDialog: React.FC<Props> = ({ category }) => {
+  const { onClose } = useContext(DialogFormContext);
+  const [updateCategory, { loading: updateLoading }] = useUpdateCategory();
+
+  const initialValues = useMemo(
+    () => ({
+      name: category.name,
+      color: category.color,
+      type: category.type,
+    }),
+    [category],
+  );
+
+  return (
+    <CategoryFormView
+      mode="update"
+      initialValues={initialValues}
+      submitLoading={updateLoading}
+      onSubmit={(values) => updateCategory(category.id, values, onClose)}
+    />
+  );
+};
+
+export default UpdateCategoryDialog;

--- a/web/src/hooks/graphql/categories.ts
+++ b/web/src/hooks/graphql/categories.ts
@@ -6,11 +6,23 @@ import {
   CreateCategoryMutation,
   CreateCategoryMutationVariables,
   DeleteCategoryMutation,
+  UpdateCategoryMutation,
+  UpdateCategoryMutationVariables,
 } from '../../@types/graphql';
 import { useRedirectedQuery, useInputMutation, useIdMutation } from './utils';
-import { IdMutationTuple, InputMutationFunction, InputMutationTuple } from '../../@types/helpers';
+import {
+  IdMutationTuple,
+  InputMutationFunction,
+  InputMutationTuple,
+  UpdateInputMutationFunction,
+} from '../../@types/helpers';
 import { useLocale } from '../utils/useLocale';
-import { createCategoryMutation, deleteCategoryMutation, myCategoriesQuery } from './queries';
+import {
+  createCategoryMutation,
+  deleteCategoryMutation,
+  myCategoriesQuery,
+  updateCategoryMutation,
+} from './queries';
 
 export const useMyCategories = (): Omit<
   QueryResult<MyCategoriesQuery, MyCategoriesQueryVariables>,
@@ -53,6 +65,33 @@ export const useCreateCategory = (): UseCreateCategoryReturn => {
   };
 
   return [createCategory, meta];
+};
+
+type UseUpdateCategoryMutationReturn = InputMutationTuple<
+  UpdateCategoryMutation,
+  UpdateCategoryMutationVariables
+>;
+
+type UseUpdateCategoryReturn = [
+  UpdateInputMutationFunction<UpdateCategoryMutationVariables['input']>,
+  UseUpdateCategoryMutationReturn[1],
+];
+
+export const useUpdateCategory = (): UseUpdateCategoryReturn => {
+  const { locale } = useLocale();
+  const [mutate, meta]: UseUpdateCategoryMutationReturn = useInputMutation(updateCategoryMutation, {
+    successMessage: locale('snackbars:success:updated', {
+      value: locale('elements:singular:category'),
+    }),
+  });
+
+  const updateCategory: UseUpdateCategoryReturn[0] = async (id, values, callback) => {
+    const response = await mutate({ id, ...values });
+    if (!response) return;
+    if (callback) await callback();
+  };
+
+  return [updateCategory, meta];
 };
 
 export const useDeleteCategory = (): IdMutationTuple<DeleteCategoryMutation> => {

--- a/web/src/hooks/graphql/queries/categories.ts
+++ b/web/src/hooks/graphql/queries/categories.ts
@@ -6,11 +6,13 @@ export const myCategoriesQuery = gql`
       id
       name
       color
+      type
     }
     expense: myCategories(type: expense) {
       id
       name
       color
+      type
     }
   }
 `;
@@ -19,6 +21,17 @@ export const createCategoryMutation = gql`
   mutation CreateCategory($input: CreateCategoryInput!) {
     createCategory(input: $input) {
       id
+    }
+  }
+`;
+
+export const updateCategoryMutation = gql`
+  mutation UpdateCategory($input: UpdateCategoryInput!) {
+    updateCategory(input: $input) {
+      id
+      name
+      type
+      color
     }
   }
 `;


### PR DESCRIPTION
# Description
Add feature to update existing categories, so that a typo or change of mind on one doesn't mean to recategorize all transactions again. The feature is available on categories view on the previously disabled button

![Screenshot_20201116_174745](https://user-images.githubusercontent.com/14133074/99306365-e37d1280-2833-11eb-829a-4c7dfc9bbabf.png)
![Screenshot_20201116_174756](https://user-images.githubusercontent.com/14133074/99306369-e4ae3f80-2833-11eb-8610-33d3d0bc3922.png)

