### PR TITLE
Feature: liquidate passives

### DIFF
--- a/backend/src/commands/LiquidatePassiveCommand.ts
+++ b/backend/src/commands/LiquidatePassiveCommand.ts
@@ -1,0 +1,123 @@
+/* eslint-disable no-param-reassign */
+import { EntityManager, getManager } from 'typeorm';
+
+import { LiquidatePassiveInput } from '../graphql/helpers';
+import Passive from '../models/Passive';
+import Account from '../models/Account';
+import { CurrentUser } from '../@types';
+import IMovementCommand from './MovementCommand';
+
+type PassiveTuple = [Passive, Passive];
+type Data = { liquidatedAccount: Account } & Omit<
+  LiquidatePassiveInput,
+  'liquidatedAccountId'
+>;
+
+export default class LiquidatePassiveCommand
+  implements IMovementCommand<PassiveTuple, Data> {
+  manager: EntityManager;
+
+  data: Data;
+
+  user: NonNullable<CurrentUser>;
+
+  constructor(
+    currentUser: NonNullable<CurrentUser>,
+    data: Data,
+    manager?: EntityManager,
+  ) {
+    this.user = currentUser;
+    this.data = data;
+    this.manager = manager || getManager();
+  }
+
+  private findPassive() {
+    const { id } = this.data;
+    return this.manager.getRepository(Passive).findOneOrFail(id);
+  }
+
+  private findOriginalAccount(passive: Passive) {
+    return this.manager.getRepository(Account).findOneOrFail(passive.accountId);
+  }
+
+  private async findAccounts(passive: Passive) {
+    const { liquidatedAccount } = this.data;
+    const originalAccount = await this.findOriginalAccount(passive);
+    const rootAccount = await this.user.getRootAccount({
+      manager: this.manager,
+    });
+
+    return {
+      originalAccount,
+      rootAccount,
+      liquidatedAccount,
+    };
+  }
+
+  private async findPassives() {
+    const passive = await this.findPassive();
+    const rootPassive = await passive.getPairedPassive();
+
+    return {
+      passive,
+      rootPassive,
+    };
+  }
+
+  private liquidatePassives(passive: Passive, rootPassive: Passive) {
+    passive.liquidated = true;
+    rootPassive.liquidated = true;
+  }
+
+  private assignLiquidatedAccount(passive: Passive, accountId: number) {
+    passive.liquidatedAccountId = accountId;
+  }
+
+  private applyBalanceChanges({
+    amount,
+    ...accounts
+  }: {
+    amount: number;
+    originalAccount: Account;
+    rootAccount: Account;
+    liquidatedAccount: Account;
+  }) {
+    Account.applyPassiveBalanceChanges({
+      amount,
+      from: accounts.originalAccount,
+      to: accounts.rootAccount,
+    });
+
+    if (accounts.originalAccount.id !== accounts.liquidatedAccount.id) {
+      Account.applyBalanceChanges({
+        amount,
+        from: accounts.originalAccount,
+        to: accounts.liquidatedAccount,
+      });
+    }
+  }
+
+  async execute(): Promise<PassiveTuple> {
+    const { passive, rootPassive } = await this.findPassives();
+    const {
+      originalAccount,
+      rootAccount,
+      liquidatedAccount,
+    } = await this.findAccounts(passive);
+
+    this.applyBalanceChanges({
+      amount: passive.amount,
+      originalAccount,
+      rootAccount,
+      liquidatedAccount,
+    });
+
+    this.liquidatePassives(passive, rootPassive);
+    this.assignLiquidatedAccount(passive, liquidatedAccount.id);
+
+    await this.manager.save([liquidatedAccount, originalAccount, rootAccount]);
+    return Passive.saveMovementPair([passive, rootPassive], {
+      manager: this.manager,
+    });
+  }
+}

--- a/backend/src/graphql/helpers/inputs/passiveInputs.ts
+++ b/backend/src/graphql/helpers/inputs/passiveInputs.ts
@@ -14,3 +14,11 @@ export class CreatePassiveInput {
   @Field(() => Date)
   issuedAt: Date;
 }
+@InputType()
+export class LiquidatePassiveInput {
+  @Field(() => ID)
+  id: number;
+
+  @Field(() => ID)
+  liquidatedAccountId: number;
+}

--- a/backend/src/migrations/1605730960957-AddLiquidatedColumnsToPassives.ts
+++ b/backend/src/migrations/1605730960957-AddLiquidatedColumnsToPassives.ts
@@ -1,0 +1,19 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddLiquidatedColumnsToPassives1605730960957 implements MigrationInterface {
+    name = 'AddLiquidatedColumnsToPassives1605730960957'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "passive" ADD "liquidated" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "passive" ADD "liquidatedAccountId" integer`);
+        await queryRunner.query(`ALTER TABLE "passive" ALTER COLUMN "liquidated" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "passive" ADD CONSTRAINT "FK_47f558017808ccc7cf8cb8069a2" FOREIGN KEY ("liquidatedAccountId") REFERENCES "account"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "passive" DROP CONSTRAINT "FK_47f558017808ccc7cf8cb8069a2"`);
+        await queryRunner.query(`ALTER TABLE "passive" DROP COLUMN "liquidatedAccountId"`);
+        await queryRunner.query(`ALTER TABLE "passive" DROP COLUMN "liquidated"`);
+    }
+
+}

--- a/backend/src/models/Passive.ts
+++ b/backend/src/models/Passive.ts
@@ -1,7 +1,30 @@
-import { Entity } from 'typeorm';
-import { ObjectType } from 'type-graphql';
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { Field, ObjectType } from 'type-graphql';
 import Movement from './Movement';
+import Account from './Account';
 
 @Entity()
 @ObjectType()
-export default class Passive extends Movement {}
+export default class Passive extends Movement {
+  @Column()
+  @Field()
+  liquidated: boolean;
+
+  @Column({ nullable: true })
+  liquidatedAccountId?: number;
+
+  @Field(() => Account, { nullable: true })
+  @ManyToOne(() => Account, { eager: false, onDelete: 'CASCADE' })
+  liquidatedAccount?: Account;
+
+  constructor(passive: {
+    amount: number;
+    accountId: number;
+    memo?: string;
+    issuedAt?: Date;
+    operationId?: string;
+  }) {
+    super(passive);
+    if (passive) this.liquidated = false;
+  }
+}

--- a/backend/src/models/Passive.ts
+++ b/backend/src/models/Passive.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, getManager, ManyToOne, Not } from 'typeorm';
 import { Field, ObjectType } from 'type-graphql';
 import Movement from './Movement';
 import Account from './Account';
@@ -16,6 +16,12 @@ export default class Passive extends Movement {
   @Field(() => Account, { nullable: true })
   @ManyToOne(() => Account, { eager: false, onDelete: 'CASCADE' })
   liquidatedAccount?: Account;
+
+  async getPairedPassive(): Promise<Passive> {
+    return getManager()
+      .getRepository(Passive)
+      .findOneOrFail({ id: Not(this.id), operationId: this.operationId });
+  }
 
   constructor(passive: {
     amount: number;

--- a/backend/src/tests/integration/commands/LiquidatePassiveCommand.test.ts
+++ b/backend/src/tests/integration/commands/LiquidatePassiveCommand.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+import { createConnection, Connection, getManager } from 'typeorm';
+
+import { seedTestDatabase, createPgClient } from '../../utils';
+import Passive from '../../../models/Passive';
+import User from '../../../models/User';
+import Account from '../../../models/Account';
+import { passiveModelFactory } from '../../factory/passiveFactory';
+import { createUser } from '../../factory/userFactory';
+import { createAccount } from '../../factory/accountFactory';
+import { AccountType } from '../../../graphql/helpers';
+import SavePassiveCommand from '../../../commands/SavePassiveCommand';
+import LiquidatePassiveCommand from '../../../commands/LiquidatePassiveCommand';
+
+const testInitialBalance = 1000;
+
+describe('passive helper tests', () => {
+  let connection: Connection;
+  const pgClient = createPgClient();
+
+  beforeAll(async () => {
+    connection = await createConnection();
+    await pgClient.connect();
+    await seedTestDatabase(pgClient);
+  });
+
+  afterAll(() => {
+    connection.close();
+    pgClient.end();
+  });
+
+  const createAndLiquidatePassive = async ({
+    user,
+    baseAccount,
+    liquidatedAccount,
+  }: {
+    user: User;
+    baseAccount: Account;
+    liquidatedAccount: Account;
+  }) => {
+    const saveCommand = new SavePassiveCommand(user, {
+      account: baseAccount,
+      ...passiveModelFactory({ account: baseAccount }).factoryPassive,
+    });
+
+    const [passive] = await saveCommand.execute();
+
+    const liquidateCommand = new LiquidatePassiveCommand(user, {
+      liquidatedAccount,
+      id: passive.id,
+    });
+
+    await liquidateCommand.execute();
+
+    return passive;
+  };
+
+  const createTestAccount = async (user: User) => {
+    const { databaseAccount } = await createAccount(connection, user.id, {
+      initialBalance: testInitialBalance,
+      type: AccountType.checking,
+    });
+
+    return databaseAccount;
+  };
+
+  describe('liquidate on same origin account', () => {
+    let updatedPassive: Passive;
+    let updatedRootPassive: Passive;
+    let testUser: User;
+    let testPassive: Passive;
+    let testAccount: Account;
+
+    beforeAll(async () => {
+      testUser = (await createUser(connection)).databaseUser;
+      testAccount = await createTestAccount(testUser);
+      testPassive = await createAndLiquidatePassive({
+        user: testUser,
+        baseAccount: testAccount,
+        liquidatedAccount: testAccount,
+      });
+
+      updatedPassive = await getManager()
+        .getRepository(Passive)
+        .findOneOrFail(testPassive.id);
+      updatedRootPassive = await updatedPassive.getPairedPassive();
+    });
+
+    it('should liquidate passives', async () => {
+      expect(updatedPassive.liquidated).toBe(true);
+      expect(updatedRootPassive.liquidated).toBe(true);
+    });
+
+    it('should assign liquidated account', async () => {
+      expect(updatedPassive.liquidatedAccountId).toBe(testAccount.id);
+      expect(updatedRootPassive.liquidatedAccountId).toBeNull();
+    });
+
+    it('should change original / liquidated account balances', async () => {
+      const updatedAccount = await getManager()
+        .getRepository(Account)
+        .findOneOrFail(testAccount.id);
+
+      expect(updatedAccount.balance).toBe(testInitialBalance);
+      expect(updatedAccount.unliquidatedBalance).toBe(0);
+    });
+
+    it('should change root account balances', async () => {
+      const updatedRootAccount = await getManager()
+        .getRepository(Account)
+        .findOneOrFail({ where: { userId: testUser.id, type: 'root' } });
+
+      expect(updatedRootAccount.balance).toBe(-testInitialBalance);
+      expect(updatedRootAccount.unliquidatedBalance).toBe(0);
+    });
+  });
+
+  describe('liquidate on other account', () => {
+    let updatedPassive: Passive;
+    let updatedRootPassive: Passive;
+    let testUser: User;
+    let testPassive: Passive;
+    let testAccount: Account;
+    let otherTestAccount: Account;
+
+    beforeAll(async () => {
+      testUser = (await createUser(connection)).databaseUser;
+      testAccount = await createTestAccount(testUser);
+      otherTestAccount = await createTestAccount(testUser);
+      testPassive = await createAndLiquidatePassive({
+        user: testUser,
+        baseAccount: testAccount,
+        liquidatedAccount: otherTestAccount,
+      });
+
+      updatedPassive = await getManager()
+        .getRepository(Passive)
+        .findOneOrFail(testPassive.id);
+
+      updatedRootPassive = await updatedPassive.getPairedPassive();
+    });
+
+    it('should liquidate passives', async () => {
+      expect(updatedPassive.liquidated).toBe(true);
+      expect(updatedRootPassive.liquidated).toBe(true);
+    });
+
+    it('should assign liquidated account', async () => {
+      expect(updatedPassive.liquidatedAccountId).toBe(otherTestAccount.id);
+      expect(updatedRootPassive.liquidatedAccountId).toBeNull();
+    });
+
+    it('should change original account balances', async () => {
+      const databaseAccount = await getManager()
+        .getRepository(Account)
+        .findOneOrFail(testAccount.id);
+      const expectedBalance = testInitialBalance - testPassive.amount;
+
+      expect(databaseAccount.balance).toBe(expectedBalance);
+      expect(databaseAccount.unliquidatedBalance).toBe(0);
+    });
+
+    it('should change liquidated account balances', async () => {
+      const databaseAccount = await getManager()
+        .getRepository(Account)
+        .findOneOrFail(otherTestAccount.id);
+      const expectedBalance = testInitialBalance + testPassive.amount;
+
+      expect(databaseAccount.balance).toBe(expectedBalance);
+      expect(databaseAccount.unliquidatedBalance).toBe(0);
+    });
+
+    it('should change root account balances', async () => {
+      const updatedRootAccount = await getManager()
+        .getRepository(Account)
+        .findOneOrFail({ where: { userId: testUser.id, type: 'root' } });
+
+      expect(updatedRootAccount.balance).toBe(-2 * testInitialBalance);
+      expect(updatedRootAccount.unliquidatedBalance).toBe(0);
+    });
+  });
+});

--- a/backend/src/tests/integration/models/Passive.test.ts
+++ b/backend/src/tests/integration/models/Passive.test.ts
@@ -1,0 +1,65 @@
+import { Connection, createConnection } from 'typeorm';
+
+import '../../../models/Transaction';
+import Passive from '../../../models/Passive';
+import Account from '../../../models/Account';
+import User from '../../../models/User';
+import SavePassiveCommand from '../../../commands/SavePassiveCommand';
+import { AccountType } from '../../../graphql/helpers';
+import { createAccount } from '../../factory/accountFactory';
+import { passiveFactory } from '../../factory/passiveFactory';
+import { createUser } from '../../factory/userFactory';
+import { createPgClient, seedTestDatabase } from '../../utils';
+
+describe('Passive model integration tests', () => {
+  let connection: Connection;
+  let testUser: User;
+  let testAccount: Account;
+
+  const pgClient = createPgClient();
+
+  beforeAll(async () => {
+    connection = await createConnection();
+    await pgClient.connect();
+
+    await seedTestDatabase(pgClient);
+
+    testUser = (await createUser(connection)).databaseUser;
+
+    testAccount = (
+      await createAccount(connection, testUser.id, {
+        type: AccountType.checking,
+        initialBalance: 0,
+      })
+    ).databaseAccount;
+  });
+
+  afterAll(() => {
+    connection.close();
+    pgClient.end();
+  });
+
+  describe('getPairedPassive', () => {
+    let testPassive: Passive;
+    let testPairedPassive: Passive;
+
+    beforeAll(async () => {
+      const command = new SavePassiveCommand(testUser, {
+        ...passiveFactory(),
+        account: testAccount,
+      });
+
+      const [passive, pairedPassive] = await command.execute();
+      testPassive = passive;
+      testPairedPassive = pairedPassive;
+    });
+
+    it('should get paired passive', async () => {
+      const pairedPassive = await testPassive.getPairedPassive();
+      expect(pairedPassive).toBeDefined();
+      expect(pairedPassive.id).toBe(testPairedPassive.id);
+      expect(pairedPassive.amount).toBe(testPairedPassive.amount);
+      expect(pairedPassive.operationId).toBe(testPairedPassive.operationId);
+    });
+  });
+});

--- a/web/src/@types/graphql.ts
+++ b/web/src/@types/graphql.ts
@@ -75,6 +75,8 @@ export type Passive = {
   issuedAt: Scalars['Timestamp'];
   createdAt: Scalars['Timestamp'];
   updatedAt: Scalars['Timestamp'];
+  liquidated: Scalars['Boolean'];
+  liquidatedAccount?: Maybe<Account>;
 };
 
 export type Account = {
@@ -176,6 +178,11 @@ export type CreatePassiveInput = {
   issuedAt: Scalars['Timestamp'];
 };
 
+export type LiquidatePassiveInput = {
+  id: Scalars['ID'];
+  liquidatedAccountId: Scalars['ID'];
+};
+
 export type CreateTransactionInput = {
   amount: Scalars['Int'];
   accountId: Scalars['ID'];
@@ -234,6 +241,7 @@ export type Mutation = {
   updateCategory: Category;
   deleteCategory: Scalars['ID'];
   createPassive: Passive;
+  liquidatePassive: Passive;
   setupDatabase?: Maybe<User>;
   createTransaction: Transaction;
   updateTransaction: Transaction;
@@ -285,6 +293,11 @@ export type MutationDeleteCategoryArgs = {
 
 export type MutationCreatePassiveArgs = {
   input: CreatePassiveInput;
+};
+
+
+export type MutationLiquidatePassiveArgs = {
+  input: LiquidatePassiveInput;
 };
 
 
@@ -467,6 +480,26 @@ export type CreatePassiveMutation = (
   & { createPassive: (
     { __typename?: 'Passive' }
     & Pick<Passive, 'id'>
+  ) }
+);
+
+export type LiquidatePassiveMutationVariables = Exact<{
+  input: LiquidatePassiveInput;
+}>;
+
+
+export type LiquidatePassiveMutation = (
+  { __typename?: 'Mutation' }
+  & { liquidatePassive: (
+    { __typename?: 'Passive' }
+    & Pick<Passive, 'id' | 'liquidated'>
+    & { account: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id' | 'name' | 'bank'>
+    ), liquidatedAccount?: Maybe<(
+      { __typename?: 'Account' }
+      & Pick<Account, 'id' | 'name' | 'bank'>
+    )> }
   ) }
 );
 

--- a/web/src/@types/locales.ts
+++ b/web/src/@types/locales.ts
@@ -27,7 +27,7 @@ type NavbarKeys =
   | 'navbar:en'
   | 'navbar:es';
 
-type FormKeys = 'forms:create' | 'forms:update' | 'forms:go' | 'forms:cancel';
+type FormKeys = 'forms:create' | 'forms:update' | 'forms:liquidate' | 'forms:go' | 'forms:cancel';
 
 type TableKeys = 'tables:actions';
 
@@ -121,6 +121,7 @@ type SnackbarKeys =
   | 'snackbars:success:updated'
   | 'snackbars:success:deleted'
   | 'snackbars:success:restored'
+  | 'snackbars:success:liquidated'
   | 'snackbars:success:done'
   | 'snackbars:errors:unknown';
 

--- a/web/src/components/passives/LiquidatePassiveDialog.tsx
+++ b/web/src/components/passives/LiquidatePassiveDialog.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import React, { useContext } from 'react';
+import { Formik, Form } from 'formik';
+import * as yup from 'yup';
+import { Grid, DialogTitle, DialogContent, makeStyles } from '@material-ui/core';
+
+import FormikSelectField from '../formik/FormikSelectField';
+import ContainerLoader from '../ui/misc/ContainerLoader';
+import DialogFormButtons from '../ui/dialogs/DialogFormButtons';
+import { useLocale } from '../../hooks/utils/useLocale';
+import { useMyDebitAccounts, useLiquidatePassive } from '../../hooks/graphql';
+import DialogFormContext from '../../contexts/DialogFormContext';
+
+type Props = {
+  passive: { id: string };
+};
+
+const useStyles = makeStyles((theme) => ({
+  form: { minWidth: theme.spacing(75), [theme.breakpoints.down('sm')]: { minWidth: 0 } },
+}));
+
+const LiquidatePassiveDialog: React.FC<Props> = ({ passive }) => {
+  const classes = useStyles();
+  const { locale } = useLocale();
+  const { onClose } = useContext(DialogFormContext);
+  const { accounts, loading: accountsLoading } = useMyDebitAccounts();
+  const [liquidatePassive, { loading: liquidateLoading }] = useLiquidatePassive();
+
+  return (
+    <Formik
+      initialValues={{
+        liquidatedAccountId: (accounts && accounts[0].id) || '',
+      }}
+      validationSchema={yup.object().shape({
+        liquidatedAccountId: yup.string().required(),
+      })}
+      onSubmit={(values) => liquidatePassive(passive.id, values, onClose)}
+    >
+      {() => (
+        <Form className={classes.form}>
+          <DialogTitle>
+            {locale('forms:liquidate')} {locale('elements:singular:passive').toLowerCase()}
+          </DialogTitle>
+          <DialogContent>
+            {accountsLoading || !accounts ? (
+              <ContainerLoader />
+            ) : (
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <FormikSelectField
+                    name="liquidatedAccountId"
+                    label={locale('movements:form:account')}
+                    fullWidth
+                    displayEmpty
+                    options={accounts.map(({ id, name, bank }) => ({
+                      key: id,
+                      label: `${name} (${bank})`,
+                    }))}
+                  />
+                </Grid>
+              </Grid>
+            )}
+          </DialogContent>
+          <DialogFormButtons loading={liquidateLoading}>
+            {locale('forms:liquidate')}
+          </DialogFormButtons>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default LiquidatePassiveDialog;

--- a/web/src/hooks/graphql/passives.ts
+++ b/web/src/hooks/graphql/passives.ts
@@ -1,7 +1,16 @@
 import { useInputMutation } from './utils';
-import { CreatePassiveMutation, CreatePassiveMutationVariables } from '../../@types/graphql';
-import { myAccountsQuery, createPassiveMutation } from './queries';
-import { InputMutationFunction, InputMutationTuple } from '../../@types/helpers';
+import {
+  CreatePassiveMutation,
+  CreatePassiveMutationVariables,
+  LiquidatePassiveMutation,
+  LiquidatePassiveMutationVariables,
+} from '../../@types/graphql';
+import { myAccountsQuery, createPassiveMutation, liquidatePassiveMutation } from './queries';
+import {
+  InputMutationFunction,
+  InputMutationTuple,
+  UpdateInputMutationFunction,
+} from '../../@types/helpers';
 import { useLocale } from '../utils/useLocale';
 
 type TExtends = { type: 'debt' | 'loan' };
@@ -40,4 +49,35 @@ export const useCreatePassive = (): UseCreatePassiveReturn => {
   };
 
   return [createPassive, meta];
+};
+
+type UseLiquidatePassiveMutationReturn = InputMutationTuple<
+  LiquidatePassiveMutation,
+  LiquidatePassiveMutationVariables
+>;
+
+type UseLiquidatePassiveReturn = [
+  UpdateInputMutationFunction<LiquidatePassiveMutationVariables['input']>,
+  UseLiquidatePassiveMutationReturn[1],
+];
+
+export const useLiquidatePassive = (): UseLiquidatePassiveReturn => {
+  const { locale } = useLocale();
+  const [mutate, meta]: UseLiquidatePassiveMutationReturn = useInputMutation(
+    liquidatePassiveMutation,
+    {
+      successMessage: locale('snackbars:success:liquidated', {
+        value: locale('elements:singular:passive'),
+      }),
+      refetchQueries: [{ query: myAccountsQuery }],
+    },
+  );
+
+  const liquidatePassive: UseLiquidatePassiveReturn[0] = async (id, input, callback) => {
+    const response = await mutate({ id, ...input });
+    if (!response) return;
+    if (callback) await callback();
+  };
+
+  return [liquidatePassive, meta];
 };

--- a/web/src/hooks/graphql/queries/passives.ts
+++ b/web/src/hooks/graphql/queries/passives.ts
@@ -7,3 +7,22 @@ export const createPassiveMutation = gql`
     }
   }
 `;
+
+export const liquidatePassiveMutation = gql`
+  mutation LiquidatePassive($input: LiquidatePassiveInput!) {
+    liquidatePassive(input: $input) {
+      id
+      liquidated
+      account {
+        id
+        name
+        bank
+      }
+      liquidatedAccount {
+        id
+        name
+        bank
+      }
+    }
+  }
+`;

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -35,6 +35,7 @@ export const en = {
   forms: {
     create: 'Create',
     update: 'Update',
+    liquidate: 'Liquidate',
     go: 'Go',
     cancel: 'Cancel',
   },
@@ -164,6 +165,7 @@ export const en = {
       updated: '{{value}} updated successfully',
       deleted: '{{value}} deleted successfully',
       restored: '{{value}} restored successfully',
+      liquidated: '{{value}} liquidated successfully',
       done: 'Action done successfully',
     },
     error: {

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -37,6 +37,7 @@ export const es: LocaleShape = {
   forms: {
     create: 'Crear',
     update: 'Modificar',
+    liquidate: 'Liquidar',
     go: 'Ir',
     cancel: 'Cancelar',
   },
@@ -166,6 +167,7 @@ export const es: LocaleShape = {
       updated: '{{value}} modificada exitosamente',
       deleted: '{{value}} borrada exitosamente',
       restored: '{{value}} restaurada exitosamente',
+      liquidated: '{{value}} liquidada exitosamente',
       done: 'Acción exitosa',
     },
     error: {


### PR DESCRIPTION
# Description
Adds the option to liquidate passives. This means that a loan or a debt is paid in an account, either the same or a different one from the original account where the money arrived/left. No UI available yet due to the dependency of a _get all passives_ feature, but it was generated.

# Additional changes
None.
