### PR TITLE
Feat/delete passives

### DIFF
--- a/backend/scripts/production_to_staging.sh
+++ b/backend/scripts/production_to_staging.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+heroku run yarn typeorm schema:drop -a balans-staging
+pg_dump -F p -f remote.sql $PRODUCTION_DB_URL
+psql $STAGING_DB_URL < remote.sql
+heroku run echo 'Migration starts automatically with docker' -a balans-staging
+rm remote.sql

--- a/backend/src/commands/DeletePassiveCommand.ts
+++ b/backend/src/commands/DeletePassiveCommand.ts
@@ -1,0 +1,74 @@
+import { EntityManager, getManager } from 'typeorm';
+
+import { CurrentUser } from '../@types';
+import Account from '../models/Account';
+import Passive from '../models/Passive';
+import IMovementCommand from './MovementCommand';
+
+type Data = { passive: Passive };
+type PassiveTuple = [Passive, Passive];
+
+export default class DeletePassiveCommand
+  implements IMovementCommand<PassiveTuple, Data> {
+  user: NonNullable<CurrentUser>;
+
+  data: Data;
+
+  manager: EntityManager;
+
+  constructor(
+    currentUser: NonNullable<CurrentUser>,
+    data: Data,
+    manager?: EntityManager,
+  ) {
+    this.user = currentUser;
+    this.data = data;
+    this.manager = manager || getManager();
+  }
+
+  private applyPaidBalanceChanges(passive: Passive) {
+    if (passive.accountId === passive.liquidatedAccountId) return;
+    Account.applyBalanceChanges({
+      amount: -passive.amount,
+      from: passive.account,
+      to: passive.liquidatedAccount!,
+    });
+  }
+
+  private applyPendingBalanceChanges(passive: Passive, rootAccount: Account) {
+    Account.applyBalanceChanges({
+      amount: -passive.amount,
+      from: passive.account,
+      to: rootAccount,
+    });
+
+    Account.applyUnliquidatedBalanceChanges({
+      amount: passive.amount,
+      from: passive.account,
+      to: rootAccount,
+    });
+  }
+
+  private applyBalanceChanges(passive: Passive, rootAccount: Account) {
+    if (passive.liquidated) this.applyPaidBalanceChanges(passive);
+    else this.applyPendingBalanceChanges(passive, rootAccount);
+  }
+
+  public async execute(): Promise<PassiveTuple> {
+    const { passive } = this.data;
+    const rootAccount = await this.user.getRootAccount();
+    const rootPassive = await passive.getPairedPassive();
+
+    this.applyBalanceChanges(passive, rootAccount);
+
+    await this.manager.save(
+      [passive.account, rootAccount, passive.liquidatedAccount].filter(
+        (acc) => !!acc,
+      ),
+    );
+
+    return Passive.removeMovementPair([passive, rootPassive], {
+      manager: this.manager,
+    });
+  }
+}

--- a/backend/src/commands/DeleteTransactionCommand.ts
+++ b/backend/src/commands/DeleteTransactionCommand.ts
@@ -1,6 +1,7 @@
 import { EntityManager, getManager } from 'typeorm';
 
 import { CurrentUser } from '../@types';
+import Account from '../models/Account';
 import Transaction from '../models/Transaction';
 import IMovementCommand from './MovementCommand';
 
@@ -30,8 +31,11 @@ export default class DeleteTransactionCommand
     const rootAccount = await this.user.getRootAccount();
     const rootTransaction = await transaction.getPairedTransaction();
 
-    transaction.account.balance -= transaction.amount;
-    rootAccount.balance += transaction.amount;
+    Account.applyBalanceChanges({
+      amount: transaction.amount,
+      from: transaction.account,
+      to: rootAccount,
+    });
 
     await this.manager.save([transaction.account, rootAccount]);
     return Transaction.removeMovementPair([transaction, rootTransaction], {

--- a/backend/src/models/Account.ts
+++ b/backend/src/models/Account.ts
@@ -99,19 +99,22 @@ export default class Account {
     data.to.balance += data.amount;
   }
 
+  static applyUnliquidatedBalanceChanges(data: {
+    amount: number;
+    from: Account;
+    to: Account;
+  }): void {
+    data.from.unliquidatedBalance -= data.amount;
+    data.to.unliquidatedBalance += data.amount;
+  }
+
   static applyPassiveBalanceChanges(data: {
     amount: number;
     from: Account;
     to: Account;
   }): void {
-    Account.applyBalanceChanges({
-      amount: -data.amount,
-      from: data.from,
-      to: data.to,
-    });
-
-    data.from.unliquidatedBalance -= data.amount;
-    data.to.unliquidatedBalance += data.amount;
+    Account.applyBalanceChanges({ ...data, amount: -data.amount });
+    Account.applyUnliquidatedBalanceChanges(data);
   }
 
   constructor(account: {

--- a/backend/src/tests/integration/commands/DeletePassiveCommand.test.ts
+++ b/backend/src/tests/integration/commands/DeletePassiveCommand.test.ts
@@ -1,0 +1,249 @@
+import { createConnection, Connection, Not } from 'typeorm';
+
+import { seedTestDatabase, createPgClient } from '../../utils';
+import Passive from '../../../models/Passive';
+import User from '../../../models/User';
+import Account from '../../../models/Account';
+import { passiveModelFactory } from '../../factory/passiveFactory';
+import { createUser } from '../../factory/userFactory';
+import { createAccount } from '../../factory/accountFactory';
+import { AccountType } from '../../../graphql/helpers';
+import SavePassiveCommand from '../../../commands/SavePassiveCommand';
+import DeletePassiveCommand from '../../../commands/DeletePassiveCommand';
+import LiquidatePassiveCommand from '../../../commands/LiquidatePassiveCommand';
+
+describe('passive helper tests', () => {
+  let connection: Connection;
+  let testUser: User;
+  let testAccount: Account;
+  let otherTestAccount: Account;
+  let testPassive: Passive;
+  const testInitialBalance = 1000;
+  const pgClient = createPgClient();
+
+  beforeAll(async () => {
+    connection = await createConnection();
+    await pgClient.connect();
+    await seedTestDatabase(pgClient);
+  });
+
+  afterAll(() => {
+    connection.close();
+    pgClient.end();
+  });
+
+  const createTestAccount = async (user: User) => {
+    const { databaseAccount } = await createAccount(connection, user.id, {
+      initialBalance: testInitialBalance,
+      type: AccountType.checking,
+    });
+
+    return databaseAccount;
+  };
+
+  const createTestPassive = async (user: User, account: Account) => {
+    const saveCommand = new SavePassiveCommand(user, {
+      account,
+      ...passiveModelFactory({ account }).factoryPassive,
+    });
+
+    const [createdPassive] = await saveCommand.execute();
+    createdPassive.account = account;
+
+    return createdPassive;
+  };
+
+  const liquidateTestPassive = async (
+    user: User,
+    passive: Passive,
+    liquidatedAccount: Account,
+  ) => {
+    const liquidateCommand = new LiquidatePassiveCommand(user, {
+      liquidatedAccount,
+      passive,
+    });
+
+    await liquidateCommand.execute();
+  };
+
+  const deleteTestPassive = async (user: User, passive: Passive) => {
+    const deleteCommand = new DeletePassiveCommand(user, {
+      passive,
+    });
+    await deleteCommand.execute();
+  };
+
+  const reloadPassive = (passive: Passive) =>
+    connection.getRepository(Passive).findOneOrFail({
+      where: { id: passive.id },
+      relations: ['account', 'liquidatedAccount'],
+    });
+
+  describe('not liquidated', () => {
+    beforeAll(async () => {
+      testUser = (await createUser(connection)).databaseUser;
+      testAccount = await createTestAccount(testUser);
+      testPassive = await createTestPassive(testUser, testAccount);
+      testPassive = await reloadPassive(testPassive);
+      await deleteTestPassive(testUser, testPassive);
+    });
+
+    it('should delete the passive', async () => {
+      const passive = await connection
+        .getRepository(Passive)
+        .findOne(testPassive.id);
+
+      expect(passive).toBeUndefined();
+    });
+
+    it('should delete the sibling passive on root account', async () => {
+      const rootPassive = await connection.getRepository(Passive).findOne({
+        id: Not(testPassive.id),
+        operationId: testPassive.operationId,
+      });
+
+      expect(rootPassive).toBeUndefined();
+    });
+
+    it('should change accounts balances', async () => {
+      const updatedRootAccount = await testUser.getRootAccount();
+      const updatedAccount = await connection
+        .getRepository(Account)
+        .findOneOrFail(testAccount.id);
+
+      const expectedBalance = testInitialBalance;
+
+      expect(updatedRootAccount.balance).toBe(-expectedBalance);
+      expect(updatedAccount.balance).toBe(expectedBalance);
+    });
+
+    it('should change accounts unliquidated balances', async () => {
+      const updatedRootAccount = await testUser.getRootAccount();
+      const updatedAccount = await connection
+        .getRepository(Account)
+        .findOneOrFail(testAccount.id);
+
+      const expectedBalance = 0;
+
+      expect(updatedRootAccount.unliquidatedBalance).toBe(expectedBalance);
+      expect(updatedAccount.unliquidatedBalance).toBe(expectedBalance);
+    });
+  });
+
+  describe('already liquidated', () => {
+    describe('different origin - liquidated accounts', () => {
+      beforeAll(async () => {
+        testUser = (await createUser(connection)).databaseUser;
+        testAccount = await createTestAccount(testUser);
+        otherTestAccount = await createTestAccount(testUser);
+        testPassive = await createTestPassive(testUser, testAccount);
+        await liquidateTestPassive(testUser, testPassive, otherTestAccount);
+        testPassive = await reloadPassive(testPassive);
+        await deleteTestPassive(testUser, testPassive);
+      });
+
+      it('should delete the passive', async () => {
+        const passive = await connection
+          .getRepository(Passive)
+          .findOne(testPassive.id);
+
+        expect(passive).toBeUndefined();
+      });
+
+      it('should delete the sibling passive on root account', async () => {
+        const rootPassive = await connection.getRepository(Passive).findOne({
+          id: Not(testPassive.id),
+          operationId: testPassive.operationId,
+        });
+
+        expect(rootPassive).toBeUndefined();
+      });
+
+      it('should change accounts balances', async () => {
+        const updatedRootAccount = await testUser.getRootAccount();
+
+        const updatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(testAccount.id);
+
+        const otherUpdatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(otherTestAccount.id);
+
+        const expectedBalance = testInitialBalance;
+
+        expect(updatedRootAccount.balance).toBe(-2 * expectedBalance);
+        expect(updatedAccount.balance).toBe(expectedBalance);
+        expect(otherUpdatedAccount.balance).toBe(expectedBalance);
+      });
+
+      it('should change accounts unliquidated balances', async () => {
+        const updatedRootAccount = await testUser.getRootAccount();
+
+        const updatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(testAccount.id);
+
+        const otherUpdatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(otherTestAccount.id);
+
+        expect(updatedRootAccount.unliquidatedBalance).toBe(0);
+        expect(updatedAccount.unliquidatedBalance).toBe(0);
+        expect(otherUpdatedAccount.unliquidatedBalance).toBe(0);
+      });
+    });
+
+    describe('same origin - liquidated accounts', () => {
+      beforeAll(async () => {
+        testUser = (await createUser(connection)).databaseUser;
+        testAccount = await createTestAccount(testUser);
+        testPassive = await createTestPassive(testUser, testAccount);
+        testPassive.account = testAccount;
+        await liquidateTestPassive(testUser, testPassive, testAccount);
+        testPassive = await reloadPassive(testPassive);
+        await deleteTestPassive(testUser, testPassive);
+      });
+
+      it('should delete the passive', async () => {
+        const passive = await connection
+          .getRepository(Passive)
+          .findOne(testPassive.id);
+
+        expect(passive).toBeUndefined();
+      });
+
+      it('should delete the sibling passive on root account', async () => {
+        const rootPassive = await connection.getRepository(Passive).findOne({
+          id: Not(testPassive.id),
+          operationId: testPassive.operationId,
+        });
+
+        expect(rootPassive).toBeUndefined();
+      });
+
+      it('should change accounts balances', async () => {
+        const updatedRootAccount = await testUser.getRootAccount();
+        const updatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(testAccount.id);
+
+        const expectedBalance = testInitialBalance;
+
+        expect(updatedRootAccount.balance).toBe(-expectedBalance);
+        expect(updatedAccount.balance).toBe(expectedBalance);
+      });
+
+      it('should change accounts unliquidated balances', async () => {
+        const updatedRootAccount = await testUser.getRootAccount();
+
+        const updatedAccount = await connection
+          .getRepository(Account)
+          .findOneOrFail(testAccount.id);
+
+        expect(updatedRootAccount.unliquidatedBalance).toBe(0);
+        expect(updatedAccount.unliquidatedBalance).toBe(0);
+      });
+    });
+  });
+});

--- a/backend/src/tests/integration/commands/LiquidatePassiveCommand.test.ts
+++ b/backend/src/tests/integration/commands/LiquidatePassiveCommand.test.ts
@@ -49,7 +49,9 @@ describe('passive helper tests', () => {
 
     const liquidateCommand = new LiquidatePassiveCommand(user, {
       liquidatedAccount,
-      id: passive.id,
+      passive: await getManager()
+        .getRepository(Passive)
+        .findOneOrFail(passive.id, { relations: ['account'] }),
     });
 
     await liquidateCommand.execute();

--- a/web/cypress/graphql.d.ts
+++ b/web/cypress/graphql.d.ts
@@ -74,6 +74,8 @@ type GQLPassive = {
   issuedAt: Scalars['Timestamp'];
   createdAt: Scalars['Timestamp'];
   updatedAt: Scalars['Timestamp'];
+  liquidated: Scalars['Boolean'];
+  liquidatedAccount?: Maybe<GQLAccount>;
 };
 
 type GQLAccount = {
@@ -174,6 +176,11 @@ type GQLCreatePassiveInput = {
   issuedAt: Scalars['Timestamp'];
 };
 
+type GQLLiquidatePassiveInput = {
+  id: Scalars['ID'];
+  liquidatedAccountId: Scalars['ID'];
+};
+
 type GQLCreateTransactionInput = {
   amount: Scalars['Int'];
   accountId: Scalars['ID'];
@@ -203,6 +210,7 @@ type GQLQuery = {
   __typename?: 'Query';
   myAccounts: Array<GQLAccount>;
   myCategories: Array<GQLCategory>;
+  myPassives: Array<GQLPassive>;
   myTransactions: Array<GQLTransaction>;
   myTransfers: Array<GQLTransfer>;
   myPairedTransfers: Array<GQLPairedTransfer>;
@@ -232,6 +240,8 @@ type GQLMutation = {
   updateCategory: GQLCategory;
   deleteCategory: Scalars['ID'];
   createPassive: GQLPassive;
+  liquidatePassive: GQLPassive;
+  deletePassive: Scalars['ID'];
   setupDatabase?: Maybe<GQLUser>;
   createTransaction: GQLTransaction;
   updateTransaction: GQLTransaction;
@@ -283,6 +293,16 @@ type GQLMutationDeleteCategoryArgs = {
 
 type GQLMutationCreatePassiveArgs = {
   input: GQLCreatePassiveInput;
+};
+
+
+type GQLMutationLiquidatePassiveArgs = {
+  input: GQLLiquidatePassiveInput;
+};
+
+
+type GQLMutationDeletePassiveArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -374,6 +394,19 @@ type GQLCreatePassiveMutationVariables = Exact<{
 type GQLCreatePassiveMutation = (
   { __typename?: 'Mutation' }
   & { createPassive: (
+    { __typename?: 'Passive' }
+    & Pick<GQLPassive, 'id'>
+  ) }
+);
+
+type GQLLiquidatePassiveMutationVariables = Exact<{
+  input: GQLLiquidatePassiveInput;
+}>;
+
+
+type GQLLiquidatePassiveMutation = (
+  { __typename?: 'Mutation' }
+  & { liquidatePassive: (
     { __typename?: 'Passive' }
     & Pick<GQLPassive, 'id'>
   ) }

--- a/web/cypress/support/commands/passive.js
+++ b/web/cypress/support/commands/passive.js
@@ -1,4 +1,4 @@
-import { createPassiveMutation } from '../graphql/passive';
+import { createPassiveMutation, liquidatePassiveMutation } from '../graphql/passive';
 
 Cypress.Commands.add('createPassive', (passiveInput) =>
   cy
@@ -7,4 +7,13 @@ Cypress.Commands.add('createPassive', (passiveInput) =>
       variables: { input: { ...passiveInput, issuedAt: passiveInput.issuedAt.valueOf() } },
     })
     .then(({ body }) => body.data.createPassive),
+);
+
+Cypress.Commands.add('liquidatePassive', (liquidateInput) =>
+  cy
+    .graphQLRequest({
+      request: liquidatePassiveMutation,
+      variables: { input: liquidateInput },
+    })
+    .then(({ body }) => body.data.liquidatePassive),
 );

--- a/web/cypress/support/graphql/passive.js
+++ b/web/cypress/support/graphql/passive.js
@@ -7,3 +7,11 @@ export const createPassiveMutation = gql`
     }
   }
 `;
+
+export const liquidatePassiveMutation = gql`
+  mutation LiquidatePassive($input: LiquidatePassiveInput!) {
+    liquidatePassive(input: $input) {
+      id
+    }
+  }
+`;

--- a/web/cypress/support/index.d.ts
+++ b/web/cypress/support/index.d.ts
@@ -91,6 +91,13 @@ declare namespace Cypress {
     createPassive(
       passive: GQLCreatePassiveMutationVariables['input'],
     ): Chainable<GQLCreatePassiveMutation['createPassive']>;
+    /**
+     * Liquidates a passive
+     * @example cy.liquidatePassive(buildPassive())
+     */
+    liquidatePassive(
+      input: GQLLiquidatePassiveMutationVariables['input'],
+    ): Chainable<GQLLiquidatePassiveMutation['liquidatePassive']>;
 
     /* Categories */
     /**

--- a/web/src/@types/graphql.ts
+++ b/web/src/@types/graphql.ts
@@ -243,6 +243,7 @@ export type Mutation = {
   deleteCategory: Scalars['ID'];
   createPassive: Passive;
   liquidatePassive: Passive;
+  deletePassive: Scalars['ID'];
   setupDatabase?: Maybe<User>;
   createTransaction: Transaction;
   updateTransaction: Transaction;
@@ -299,6 +300,11 @@ export type MutationCreatePassiveArgs = {
 
 export type MutationLiquidatePassiveArgs = {
   input: LiquidatePassiveInput;
+};
+
+
+export type MutationDeletePassiveArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -517,6 +523,16 @@ export type LiquidatePassiveMutation = (
       & Pick<Account, 'id' | 'name' | 'bank'>
     )> }
   ) }
+);
+
+export type DeletePassiveMutationVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type DeletePassiveMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'deletePassive'>
 );
 
 export type MyTransactionsQueryVariables = Exact<{ [key: string]: never; }>;

--- a/web/src/components/passives/PassiveActionCell.tsx
+++ b/web/src/components/passives/PassiveActionCell.tsx
@@ -7,6 +7,7 @@ import { MyPassivesQuery } from '../../@types/graphql';
 import EnhancedIconButton from '../ui/misc/EnhancedIconButton';
 import DialogIconButton from '../ui/dialogs/DialogIconButton';
 import LiquidatePassiveDialog from './LiquidatePassiveDialog';
+import { useDeletePassive } from '../../hooks/graphql';
 
 const useStyles = makeStyles((theme) => ({
   wrapper: {
@@ -18,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
 
 const PassiveActionCell: React.FC<CellProps<MyPassivesQuery['passives'][number]>> = ({ row }) => {
   const classes = useStyles();
+  const [deletePassive, { loading }] = useDeletePassive();
   const { id, liquidated } = row.original;
 
   return (
@@ -35,7 +37,13 @@ const PassiveActionCell: React.FC<CellProps<MyPassivesQuery['passives'][number]>
       <EnhancedIconButton contained disabled data-testid={`updatePassive${id}`} color="info">
         <EditIcon />
       </EnhancedIconButton>
-      <EnhancedIconButton contained disabled data-testid={`deletePassive${id}`} color="error">
+      <EnhancedIconButton
+        contained
+        disabled={loading}
+        data-testid={`deletePassive${id}`}
+        color="error"
+        onClick={() => deletePassive(row.original.id)}
+      >
         <DeleteIcon />
       </EnhancedIconButton>
     </Box>

--- a/web/src/components/passives/PassivesList.tsx
+++ b/web/src/components/passives/PassivesList.tsx
@@ -17,6 +17,7 @@ import DialogIconButton from '../ui/dialogs/DialogIconButton';
 import { useLocale } from '../../hooks/utils/useLocale';
 import LiquidatePassiveDialog from './LiquidatePassiveDialog';
 import AmountTypography from '../ui/dataDisplay/AmountTypography';
+import { useDeletePassive } from '../../hooks/graphql';
 
 type Props = {
   passives: MyPassivesQuery['passives'];
@@ -37,6 +38,7 @@ const useStyles = makeStyles((theme) => ({
 
 const PassivesList: React.FC<Props> = ({ passives, loading, noAccountsCreated }) => {
   const { locale } = useLocale();
+  const [deletePassive, { loading: deleteLoading }] = useDeletePassive();
   const classes = useStyles();
 
   return (
@@ -79,9 +81,10 @@ const PassivesList: React.FC<Props> = ({ passives, loading, noAccountsCreated })
                   </EnhancedIconButton>
                   <EnhancedIconButton
                     contained
-                    disabled
+                    disabled={deleteLoading}
                     data-testid={`deletePassive${id}`}
                     color="error"
+                    onClick={() => deletePassive(id)}
                   >
                     <DeleteIcon fontSize="small" />
                   </EnhancedIconButton>

--- a/web/src/hooks/graphql/passives.ts
+++ b/web/src/hooks/graphql/passives.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { QueryResult } from '@apollo/client';
-import { useInputMutation, useRedirectedQuery } from './utils';
+import { useIdMutation, useInputMutation, useRedirectedQuery } from './utils';
 import {
   CreatePassiveMutation,
   CreatePassiveMutationVariables,
@@ -8,14 +8,17 @@ import {
   LiquidatePassiveMutationVariables,
   MyPassivesQuery,
   MyPassivesQueryVariables,
+  DeletePassiveMutation,
 } from '../../@types/graphql';
 import {
   myAccountsQuery,
   createPassiveMutation,
   liquidatePassiveMutation,
   myPassivesQuery,
+  deletePassiveMutation,
 } from './queries';
 import {
+  IdMutationTuple,
   InputMutationFunction,
   InputMutationTuple,
   UpdateInputMutationFunction,
@@ -98,4 +101,15 @@ export const useLiquidatePassive = (): UseLiquidatePassiveReturn => {
   };
 
   return [liquidatePassive, meta];
+};
+
+export const useDeletePassive = (): IdMutationTuple<DeletePassiveMutation> => {
+  const { locale } = useLocale();
+
+  return useIdMutation<DeletePassiveMutation>(deletePassiveMutation, {
+    refetchQueries: [{ query: myAccountsQuery }, { query: myPassivesQuery }],
+    successMessage: locale('snackbars:success:deleted', {
+      value: locale('elements:singular:passive'),
+    }),
+  });
 };

--- a/web/src/hooks/graphql/queries/passives.ts
+++ b/web/src/hooks/graphql/queries/passives.ts
@@ -43,3 +43,9 @@ export const liquidatePassiveMutation = gql`
     }
   }
 `;
+
+export const deletePassiveMutation = gql`
+  mutation DeletePassive($id: ID!) {
+    deletePassive(id: $id)
+  }
+`;


### PR DESCRIPTION
# Description
Add the possibility of deleting passives. It results on different combination of balance changes due to the complexity of a liquidated / unliquidated passive. Here's a screenshot of the feature

![Screenshot_20201119_121038](https://user-images.githubusercontent.com/14133074/99686072-fc6b0b00-2a61-11eb-82b9-4b06f446f6ff.png)

# Additional changes
- Refactor to `DeleteTransactionCommand` so it uses `Account.applyBalanceChanges` instead of manually triggering them
- Refactor to `LiquidatePassiveCommand` to receive a `passive`, so that it separates behaviour better.
- Refactor to `Account.applyPassiveBalanceChanges` to access `Account.applyUnliquidatedBalanceChanges` separately.
