### PR TITLE
fix(passives): issue with paying passives on mobile view

### DIFF
--- a/web/src/components/passives/LiquidatePassiveDialog.tsx
+++ b/web/src/components/passives/LiquidatePassiveDialog.tsx
@@ -49,7 +49,7 @@ const LiquidatePassiveDialog: React.FC<Props> = ({ passive }) => {
                 <Grid item xs={12}>
                   <FormikSelectField
                     name="liquidatedAccountId"
-                    label={locale('movements:form:account')}
+                    label={locale('elements:singular:liquidatedAccount')}
                     fullWidth
                     displayEmpty
                     options={accounts.map(({ id, name, bank }) => ({

--- a/web/src/components/passives/PassivesList.tsx
+++ b/web/src/components/passives/PassivesList.tsx
@@ -64,9 +64,8 @@ const PassivesList: React.FC<Props> = ({ passives, loading, noAccountsCreated })
                 <ListItemSecondaryAction className={classes.secondaryActions}>
                   <DialogIconButton
                     contained
-                    disabled
-                    data-testid={`updatePassive${id}`}
-                    color="info"
+                    data-testid={`liquidatePassive${id}`}
+                    color="warning"
                     icon={<PaymentIcon />}
                   >
                     <LiquidatePassiveDialog passive={data[index]} />


### PR DESCRIPTION
# Description
Fixed a small bug that prevented payment of passives on mobile responsive view. Now it looks like it should:

![Screenshot_20201121_120001](https://user-images.githubusercontent.com/14133074/99880252-1be46e00-2bf1-11eb-8783-d92de759455f.png)

# Additional changes
- Changed the name of the account to liquidate on `LiquidatePassiveDialog`
