### PR TITLE
fix: restrict root resources

### DIFF
--- a/backend/src/commands/SavePassiveCommand.ts
+++ b/backend/src/commands/SavePassiveCommand.ts
@@ -50,6 +50,7 @@ export default class SavePassiveCommand
         accountId: rootAccount.id,
         operationId,
         issuedAt,
+        root: true,
       }),
     };
   }

--- a/backend/src/commands/SaveTransactionCommand.ts
+++ b/backend/src/commands/SaveTransactionCommand.ts
@@ -59,6 +59,7 @@ export default class SaveTransactionCommand
         accountId: rootAccount.id,
         operationId,
         issuedAt,
+        root: true,
       }),
     };
   }

--- a/backend/src/graphql/resolvers/passiveResolvers.ts
+++ b/backend/src/graphql/resolvers/passiveResolvers.ts
@@ -81,6 +81,7 @@ export default class PassiveResolvers {
       .leftJoinAndSelect('passive.account', 'account')
       .where('account.userId = :userId', { userId: currentUser!.id })
       .andWhere('passive.id = :id', { id })
+      .andWhere('passive.root = false')
       .getOne();
 
     if (!passive) throw new NotFoundError('passive');

--- a/backend/src/graphql/resolvers/transactionResolver.ts
+++ b/backend/src/graphql/resolvers/transactionResolver.ts
@@ -91,6 +91,7 @@ export default class TransactionResolvers {
       .leftJoinAndSelect('transaction.account', 'account')
       .where('account.userId = :userId', { userId: currentUser!.id })
       .andWhere('transaction.id = :id', { id })
+      .andWhere('transaction.root = false')
       .getOne();
 
     if (!transaction) throw new NotFoundError('transaction');
@@ -119,6 +120,7 @@ export default class TransactionResolvers {
       .leftJoinAndSelect('transaction.account', 'account')
       .where('account.userId = :userId', { userId: currentUser!.id })
       .andWhere('transaction.id = :id', { id })
+      .andWhere('transaction.root = false')
       .getOne();
 
     if (!transaction) throw new NotFoundError('transaction');

--- a/backend/src/migrations/1605897483447-AddRootFlagToMovements.ts
+++ b/backend/src/migrations/1605897483447-AddRootFlagToMovements.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRootFlagToMovements1605897483447 implements MigrationInterface {
+  name = 'AddRootFlagToMovements1605897483447';
+
+  private async updateRootMovements(
+    queryRunner: QueryRunner,
+    data: {
+      ids: number[];
+      movementType: 'passive' | 'transaction';
+    },
+  ) {
+    const ids = data.ids.join(', ');
+    await queryRunner.query(
+      `UPDATE "${data.movementType}" SET "root" = true, "memo" = '' WHERE "id" IN (${ids})`,
+    );
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ADD "root" boolean NOT NULL DEFAULT false`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "passive" ADD "root" boolean NOT NULL DEFAULT false`,
+    );
+
+    const rootPassives: { id: number }[] = await queryRunner.query(
+      `SELECT "id" FROM "passive" WHERE memo LIKE '%(root)%'`,
+    );
+
+    const rootTransactions: { id: number }[] = await queryRunner.query(
+      `SELECT "id" FROM "transaction" WHERE memo LIKE '%(root)%'`,
+    );
+
+    if (rootTransactions.length > 0) {
+      await this.updateRootMovements(queryRunner, {
+        ids: rootTransactions.map(({ id }) => id),
+        movementType: 'transaction',
+      });
+    }
+
+    if (rootPassives.length > 0) {
+      await this.updateRootMovements(queryRunner, {
+        ids: rootPassives.map(({ id }) => id),
+        movementType: 'passive',
+      });
+    }
+
+    await queryRunner.query(
+      `ALTER TABLE "passive" ALTER COLUMN "root" DROP DEFAULT`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ALTER COLUMN "root" DROP DEFAULT`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "passive" DROP COLUMN "root"`);
+    await queryRunner.query(`ALTER TABLE "transaction" DROP COLUMN "root"`);
+  }
+}

--- a/backend/src/models/Passive.ts
+++ b/backend/src/models/Passive.ts
@@ -13,6 +13,9 @@ export default class Passive extends Movement {
   @Column({ nullable: true })
   liquidatedAccountId?: number;
 
+  @Column()
+  root: boolean;
+
   @Field(() => Account, { nullable: true })
   @ManyToOne(() => Account, { eager: false, onDelete: 'CASCADE' })
   liquidatedAccount?: Account;
@@ -20,7 +23,11 @@ export default class Passive extends Movement {
   async getPairedPassive(): Promise<Passive> {
     return getManager()
       .getRepository(Passive)
-      .findOneOrFail({ id: Not(this.id), operationId: this.operationId });
+      .findOneOrFail({
+        id: Not(this.id),
+        operationId: this.operationId,
+        root: true,
+      });
   }
 
   constructor(passive: {
@@ -29,8 +36,12 @@ export default class Passive extends Movement {
     memo?: string;
     issuedAt?: Date;
     operationId?: string;
+    root?: boolean;
   }) {
     super(passive);
-    if (passive) this.liquidated = false;
+    if (passive) {
+      this.liquidated = false;
+      this.root = passive.root || false;
+    }
   }
 }

--- a/backend/src/models/Transaction.ts
+++ b/backend/src/models/Transaction.ts
@@ -22,6 +22,9 @@ export default class Transaction extends Movement {
   @IsValidCategory()
   category?: Category;
 
+  @Column()
+  root: boolean;
+
   @Field({ nullable: true })
   @DeleteDateColumn()
   deletedAt: Date;
@@ -29,7 +32,11 @@ export default class Transaction extends Movement {
   async getPairedTransaction(): Promise<Transaction> {
     return getManager()
       .getRepository(Transaction)
-      .findOneOrFail({ id: Not(this.id), operationId: this.operationId });
+      .findOneOrFail({
+        id: Not(this.id),
+        operationId: this.operationId,
+        root: true,
+      });
   }
 
   constructor(transaction: {
@@ -39,10 +46,12 @@ export default class Transaction extends Movement {
     memo?: string;
     operationId?: string;
     category?: Category;
+    root?: boolean;
   }) {
     super(transaction);
     if (transaction) {
       this.category = transaction.category;
+      this.root = transaction.root || false;
     }
   }
 }

--- a/backend/src/tests/integration/api/account.test.ts
+++ b/backend/src/tests/integration/api/account.test.ts
@@ -201,6 +201,18 @@ describe('account API calls', () => {
       ).rejects.toBeTruthy();
     });
 
+    it('should not delete an account if root', async () => {
+      const rootAccount = await testUser.getRootAccount();
+
+      const { mutate } = await mountTestClient({ currentUser: testUser });
+      const response = await mutate({
+        mutation: DELETE_ACCOUNT,
+        variables: { id: rootAccount.id },
+      });
+
+      expect(response).toBeRejected();
+    });
+
     it('should not delete an account if not mine', async () => {
       const otherUser = (await createUser(connection)).databaseUser;
       const createdAccount = (await createAccount(connection, otherUser.id))

--- a/backend/src/tests/integration/commands/SavePassiveCommand.test.ts
+++ b/backend/src/tests/integration/commands/SavePassiveCommand.test.ts
@@ -21,7 +21,7 @@ describe('passive helper tests', () => {
   let testUser: User;
   let testAccount: Account;
   let testPassive: Passive;
-  let rootPassive: Passive;
+  let testRootPassive: Passive;
 
   const testPassives: Passive[] = [];
   const testAmounts: number[] = [];
@@ -66,11 +66,11 @@ describe('passive helper tests', () => {
   });
 
   const getPassivePair = async (operationId: string) => {
-    const [passive, _rootPassive] = await getRepository(Passive).find({
+    const [passive, rootPassive] = await getRepository(Passive).find({
       operationId,
     });
 
-    return { passive, rootPassive: _rootPassive };
+    return { passive, rootPassive };
   };
 
   it('should change account balances', async () => {
@@ -98,18 +98,23 @@ describe('passive helper tests', () => {
         const passives = await getPassivePair(testPassives[idx].operationId);
 
         testPassive = passives.passive;
-        rootPassive = passives.rootPassive;
+        testRootPassive = passives.rootPassive;
       });
 
       it('should create passive pairs', async () => {
         expect(testPassive).toBeDefined();
-        expect(rootPassive).toBeDefined();
+        expect(testRootPassive).toBeDefined();
+      });
+
+      it('should have correct root flags', async () => {
+        expect(testPassive.root).toBe(false);
+        expect(testRootPassive.root).toBe(true);
       });
 
       it('should have correct values', async () => {
         const expectedAmount = testPassives[idx].amount;
         expect(testPassive.amount).toBe(expectedAmount);
-        expect(rootPassive.amount).toBe(-expectedAmount);
+        expect(testRootPassive.amount).toBe(-expectedAmount);
       });
     });
   });

--- a/backend/src/tests/integration/commands/SaveTransactionCommand.test.ts
+++ b/backend/src/tests/integration/commands/SaveTransactionCommand.test.ts
@@ -26,7 +26,7 @@ describe('transaction helper tests', () => {
   let testAccount: Account;
   let testCategories: CategoryPair;
   let testTransaction: Transaction;
-  let rootTransaction: Transaction;
+  let testRootTransaction: Transaction;
 
   const testTransactions: Transaction[] = [];
   const testAmounts: number[] = [];
@@ -74,11 +74,11 @@ describe('transaction helper tests', () => {
   });
 
   const getTransactionPair = async (operationId: string) => {
-    const [transaction, _rootTransaction] = await getRepository(
+    const [transaction, rootTransaction] = await getRepository(
       Transaction,
     ).find({ operationId });
 
-    return { transaction, rootTransaction: _rootTransaction };
+    return { transaction, rootTransaction };
   };
 
   it('should change account balances', async () => {
@@ -102,18 +102,23 @@ describe('transaction helper tests', () => {
         );
 
         testTransaction = transactions.transaction;
-        rootTransaction = transactions.rootTransaction;
+        testRootTransaction = transactions.rootTransaction;
       });
 
       it('should create transaction pairs', async () => {
         expect(testTransaction).toBeDefined();
-        expect(rootTransaction).toBeDefined();
+        expect(testRootTransaction).toBeDefined();
+      });
+
+      it('should have correct root flags', async () => {
+        expect(testTransaction.root).toBe(false);
+        expect(testRootTransaction.root).toBe(true);
       });
 
       it('should have correct values', async () => {
         const expectedAmount = testTransactions[idx].amount;
         expect(testTransaction.amount).toBe(expectedAmount);
-        expect(rootTransaction.amount).toBe(-expectedAmount);
+        expect(testRootTransaction.amount).toBe(-expectedAmount);
       });
     });
   });


### PR DESCRIPTION
# Description
API had a bug related to user being able to update, delete and liquidate root movements through manual requests. These movements aren't supposed to be exposed.

In order to do this, I added a `root` flag to the corresponding movements and now database queries look for movements with that flag setted to `false`, so a root transaction will not exist via the API for the user.

# Additional changes
None.
